### PR TITLE
Improve compatibility

### DIFF
--- a/translate.awk
+++ b/translate.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env gawk -f
 # ----------------------------------------------------------------------------
 # "THE BEER-WARE LICENSE" (Revision 42):
 # <mort.yao@gmail.com> wrote this file. As long as you retain this notice you


### PR DESCRIPTION
Use `/usr/bin/env gawk` instead of `/usr/bin/awk` to improve compatibility with systems on which `gawk` may not be placed at `/usr/bin`, and report a more accurate error information rather than syntax error or illegal statement error when GNU awk is not installed.
