### PR TITLE
Add option '-proxy'

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ See the man page trans(1) for more information.
 You can export some environment variables as your default configuration. This will save you from typing the same command-line options each time.
 
 * `PLAYER`: for option `-player`
+* `HTTP_PROXY` and `http_proxy`: for option `-proxy`
 * `TRANS_PS`: for option `-prompt`
 * `TRANS_PS_COLOR`: for option `-prompt-color`
 * `HOME_LANG`: for option `-l`

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -87,6 +87,7 @@ function getHelp() {
         "  " AnsiCode["bold"] "-w [num], -width [num]" AnsiCode["no bold"] "\n    Specify the screen width for padding when displaying right-to-left languages.\n" \
         "  " AnsiCode["bold"] "-p, -play" AnsiCode["no bold"] "\n    Listen to the translation.\n" \
         "  " AnsiCode["bold"] "-player [program]" AnsiCode["no bold"] "\n    Specify the command-line audio player to use, and listen to the translation.\n" \
+        "  " AnsiCode["bold"] "-x [proxy], -proxy [proxy]" AnsiCode["no bold"] "\n    Use proxy on given port.\n" \
         "  " AnsiCode["bold"] "-I, -interactive" AnsiCode["no bold"] "\n    Start an interactive shell, invoking `rlwrap` whenever possible (unless `-no-rlwrap` is specified).\n" \
         "  " AnsiCode["bold"] "-no-rlwrap" AnsiCode["no bold"] "\n    Don't invoke `rlwrap` when starting an interactive shell with `-I`.\n" \
         "  " AnsiCode["bold"] "-E, -emacs" AnsiCode["no bold"] "\n    Start an interactive shell within GNU Emacs, invoking `emacs`.\n" \

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -137,8 +137,8 @@ BEGIN {
         match(ARGV[pos], /^--?player(=(.*)?)?$/, group)
         if (RSTART) {
             Option["play"] = 1
-            Option["player"] = group[2] ?
-                (group[3] ? group[3] : Option["player"]) :
+            Option["player"] = group[1] ?
+                (group[2] ? group[2] : Option["player"]) :
                 ARGV[++pos]
             continue
         }

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -25,8 +25,9 @@ function initHttpService() {
     HttpProtocol = "http://"
     HttpHost = "translate.google.com"
     HttpPort = 80
-    if(match(ENVIRON["http_proxy"], /^http:\/*([^\/]*):([^\/:]*)/, HttpProxySpec)) {
-        HttpService = "/inet/tcp/0/" HttpProxySpec[1] "/" HttpProxySpec[2]
+    if (Option["proxy"]) {
+        match(Option["proxy"], /^(http:\/*)?([^\/]*):([^\/:]*)/, HttpProxySpec)
+        HttpService = "/inet/tcp/0/" HttpProxySpec[2] "/" HttpProxySpec[3]
         HttpPathPrefix = HttpProtocol HttpHost
     } else {
         HttpService = "/inet/tcp/0/" HttpHost "/" HttpPort
@@ -48,7 +49,7 @@ function postprocess(text) {
 
 # Send an HTTP request and get response from Google Translate.
 function getResponse(text, sl, tl, hl,    content, url) {
-    url = HttpPathPrefix "/translate_a/t?client=t"              \
+    url = "/translate_a/t?client=t"                             \
         "&ie=UTF-8&oe=UTF-8"                                    \
         "&text=" preprocess(text) "&sl=" sl "&tl=" tl "&hl=" hl
 

--- a/man/trans.1
+++ b/man/trans.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "TRANS" "1" "August 2014" "0.8.19" "TRANS MANUAL"
+.TH "TRANS" "1" "September 2014" "0.8.19" "TRANS MANUAL"
 .
 .SH "NAME"
 \fBtrans\fR \- Google Translate served as a command\-line tool
@@ -79,6 +79,22 @@ Option \fB\-play\fR will try to use \fBmplayer\fR or \fBmpg123\fR by default, si
 .
 .P
 This option overrides the setting of environment variable \fBPLAYER\fR\.
+.
+.SS "\-x [proxy], \-proxy [proxy]"
+Use proxy on given port\. String format:
+.
+.IP "" 4
+.
+.nf
+
+[PROTOCOL://]HOST[:PORT]
+.
+.fi
+.
+.IP "" 0
+.
+.P
+This option overrides the setting of environment variables \fBHTTP_PROXY\fR and \fBhttp_proxy\fR\.
 .
 .SS "\-I, \-interactive"
 Start an interactive shell, invoking \fBrlwrap\fR whenever possible (unless \fB\-no\-rlwrap\fR is specified)\.

--- a/man/trans.1.ronn
+++ b/man/trans.1.ronn
@@ -75,6 +75,16 @@ Option `-play` will try to use `mplayer` or `mpg123` by default, since these pla
 
 This option overrides the setting of environment variable `PLAYER`.
 
+### -x [proxy], -proxy [proxy]
+
+Use proxy on given port. String format:
+
+```
+[PROTOCOL://]HOST[:PORT]
+```
+
+This option overrides the setting of environment variables `HTTP_PROXY` and `http_proxy`.
+
 ### -I, -interactive
 
 Start an interactive shell, invoking `rlwrap` whenever possible (unless `-no-rlwrap` is specified).


### PR DESCRIPTION
A follow-up on #22:

Add option `-proxy` and `-x [PROTOCOL://]HOST[:PORT]` to specify a proxy on a given port.

Two environment variables are also available:
- `HTTP_PROXY`
- `http_proxy`
