### PR TITLE
Translate a website (supporting URI schemes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,22 @@ Translations will be written to standard output, or to the file specified by the
 
     $ echo "Saluton, Mondo" | trans :fr -b -o output.txt
 
+### Translate a File
+
+Instead of using the `-input` option, a URI scheme of file can be provided as a parameter (`file://` followed by the file name):
+
+    $ trans :fr file://input.txt
+
+Brief mode is used when translating URI schemes.
+
+### Translate a Web Page
+
+For the translation of a web page, a URI scheme of HTTP(S) can be provided as a parameter:
+
+    $ trans :fr http://www.w3.org/
+
+A browser session will be started for viewing. To specify the web browser, use the `-browser` option.
+
 ### Interactive Mode
 
 Start an interactive shell, using the `-interactive` option:

--- a/README.md
+++ b/README.md
@@ -269,10 +269,14 @@ Options:
     Brief mode.
   -w [num], -width [num]
     Specify the screen width for padding when displaying right-to-left languages.
+  -browser [program]
+    Specify the web browser to use.
   -p, -play
     Listen to the translation.
   -player [program]
     Specify the command-line audio player to use, and listen to the translation.
+  -x [proxy], -proxy [proxy]
+    Use proxy on given port.
   -I, -interactive
     Start an interactive shell, invoking `rlwrap` whenever possible (unless `-no-rlwrap` is specified).
   -no-rlwrap

--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ See the man page trans(1) for more information.
 
 You can export some environment variables as your default configuration. This will save you from typing the same command-line options each time.
 
+* `BROWSER`: for option `-browser`
 * `PLAYER`: for option `-player`
 * `HTTP_PROXY` and `http_proxy`: for option `-proxy`
 * `TRANS_PS`: for option `-prompt`

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ For the translation of a web page, a URI scheme of HTTP(S) can be provided as a 
 
     $ trans :fr http://www.w3.org/
 
-A browser session will be started for viewing. To specify the web browser, use the `-browser` option.
+A browser session will be started for viewing the translation (in Google Translate). To specify the web browser, use the `-browser` option.
 
 ### Interactive Mode
 

--- a/include/Commons.awk
+++ b/include/Commons.awk
@@ -295,7 +295,15 @@ function fileExists(file) {
     return !system("test -f " file)
 }
 
+# Initialize `UriSchemes`.
+function initUriSchemes() {
+    UriSchemes[0] = "file"
+    UriSchemes[1] = "http"
+    UriSchemes[2] = "https"
+}
+
 BEGIN {
     initUrlEncoding()
     initAnsiCode()
+    initUriSchemes()
 }

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -85,6 +85,7 @@ function getHelp() {
         "  " AnsiCode["bold"] "-v, -verbose" AnsiCode["no bold"] "\n    Verbose mode. (default)\n" \
         "  " AnsiCode["bold"] "-b, -brief" AnsiCode["no bold"] "\n    Brief mode.\n" \
         "  " AnsiCode["bold"] "-w [num], -width [num]" AnsiCode["no bold"] "\n    Specify the screen width for padding when displaying right-to-left languages.\n" \
+        "  " AnsiCode["bold"] "-browser [program]" AnsiCode["no bold"] "\n    Specify the web browser to use.\n" \
         "  " AnsiCode["bold"] "-p, -play" AnsiCode["no bold"] "\n    Listen to the translation.\n" \
         "  " AnsiCode["bold"] "-player [program]" AnsiCode["no bold"] "\n    Specify the command-line audio player to use, and listen to the translation.\n" \
         "  " AnsiCode["bold"] "-x [proxy], -proxy [proxy]" AnsiCode["no bold"] "\n    Use proxy on given port.\n" \

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -33,6 +33,8 @@ function preInit() {
     Option["verbose"] = 1
     Option["width"] = ENVIRON["COLUMNS"] ? ENVIRON["COLUMNS"] : 64
 
+    Option["browser"] = ENVIRON["BROWSER"]
+
     Option["play"] = 0
     Option["player"] = ENVIRON["PLAYER"]
 
@@ -131,6 +133,15 @@ BEGIN {
             continue
         }
 
+        # -browser [program]
+        match(ARGV[pos], /^--?browser(=(.*)?)?$/, group)
+        if (RSTART) {
+            Option["browser"] = group[1] ?
+                (group[2] ? group[2] : Option["browser"]) :
+                ARGV[++pos]
+            continue
+        }
+
         # -p, -play
         match(ARGV[pos], /^--?p(l(ay?)?)?$/)
         if (RSTART) {
@@ -148,7 +159,7 @@ BEGIN {
             continue
         }
 
-        # -proxy [proxy]
+        # -x [proxy], -proxy [proxy]
         match(ARGV[pos], /^--?(proxy|x)(=(.*)?)?$/, group)
         if (RSTART) {
             Option["proxy"] = group[2] ?
@@ -328,10 +339,17 @@ BEGIN {
         }
     }
 
+    # Initialize browser
+    if (!Option["browser"]) {
+        "xdg-mime query default text/html 2>/dev/null" |& getline Option["browser"]
+        match(Option["browser"], "(.*).desktop$", group)
+        Option["browser"] = group[1]
+    }
+
     if (pos < ARGC) {
         # More parameters
 
-        # Translate the rest parameters
+        # Translate the remaining parameters
         for (i = pos; i < ARGC; i++) {
             # Verbose mode: separator between sources
             if (Option["verbose"] && i > pos)

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -355,7 +355,7 @@ BEGIN {
             if (Option["verbose"] && i > pos)
                 print replicate("═", Option["width"])
 
-            translate(ARGV[i])
+            translate(ARGV[i], 1) # inline mode
         }
 
         # If input not specified, we're done

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -231,8 +231,14 @@ function getTranslation(text, sl, tl, hl,
     return r
 }
 
+# Start a browser session and translate a web page.
+function webTranslation(uri, sl, tl, hl) {
+    system(Option["browser"] " " parameterize("https://translate.google.com/translate?" \
+                                              "hl=" hl "&sl=" sl "&tl=" tl "&u=" uri) "&")
+}
+
 # Translate the source text (into all target languages).
-function translate(text,
+function translate(text, inline,
                    ####
                    i, j, playlist, saveSortedIn) {
 
@@ -263,15 +269,21 @@ function translate(text,
             if (Option["verbose"] && i > 1)
                 print replicate("─", Option["width"])
 
-        print getTranslation(text, Option["sl"], Option["tl"][i], Option["hl"], Option["verbose"], Option["play"], playlist) > Option["output"]
+        if (inline &&
+            startsWithAny(text, UriSchemes) == "http" ||
+            startsWithAny(text, UriSchemes) == "https") {
+            webTranslation(text, Option["sl"], Option["tl"][i], Option["hl"])
+        } else {
+            print getTranslation(text, Option["sl"], Option["tl"][i], Option["hl"], Option["verbose"], Option["play"], playlist) > Option["output"]
 
-        if (Option["play"])
-            if (Option["player"])
-                for (j in playlist)
-                    play(playlist[j]["text"], playlist[j]["tl"])
-            else if (SpeechSynthesizer)
-                for (j in playlist)
-                    print playlist[j]["text"] | SpeechSynthesizer
+            if (Option["play"])
+                if (Option["player"])
+                    for (j in playlist)
+                        play(playlist[j]["text"], playlist[j]["tl"])
+                else if (SpeechSynthesizer)
+                    for (j in playlist)
+                        print playlist[j]["text"] | SpeechSynthesizer
+        }
     }
     PROCINFO["sorted_in"] = saveSortedIn
 }

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -231,6 +231,21 @@ function getTranslation(text, sl, tl, hl,
     return r
 }
 
+# Translate a file.
+function fileTranslation(uri,    group, temp1, temp2) {
+    temp1 = Option["input"]
+    temp2 = Option["verbose"]
+
+    match(uri, /^file:\/\/(.*)/, group)
+    Option["input"] = group[1]
+    Option["verbose"] = 0
+
+    translateMain()
+
+    Option["input"] = temp1
+    Option["verbose"] = temp2
+}
+
 # Start a browser session and translate a web page.
 function webTranslation(uri, sl, tl, hl) {
     system(Option["browser"] " " parameterize("https://translate.google.com/translate?" \
@@ -270,8 +285,11 @@ function translate(text, inline,
                 print replicate("─", Option["width"])
 
         if (inline &&
-            startsWithAny(text, UriSchemes) == "http" ||
-            startsWithAny(text, UriSchemes) == "https") {
+            startsWithAny(text, UriSchemes) == "file") {
+            fileTranslation(text)
+        } else if (inline &&
+                   startsWithAny(text, UriSchemes) == "http" ||
+                   startsWithAny(text, UriSchemes) == "https") {
             webTranslation(text, Option["sl"], Option["tl"][i], Option["hl"])
         } else {
             print getTranslation(text, Option["sl"], Option["tl"][i], Option["hl"], Option["verbose"], Option["play"], playlist) > Option["output"]

--- a/man/trans.1
+++ b/man/trans.1
@@ -62,6 +62,12 @@ Specify the screen width for padding when displaying right\-to\-left languages\.
 .P
 This option overrides the setting of environment variable \fBCOLUMNS\fR\.
 .
+.SS "\-browser [program]"
+Specify the web browser to use\.
+.
+.P
+This option overrides the setting of environment variable \fBBROWSER\fR\.
+.
 .SS "\-p, \-play"
 Listen to the translation\.
 .

--- a/man/trans.1.ronn
+++ b/man/trans.1.ronn
@@ -59,6 +59,12 @@ Specify the screen width for padding when displaying right-to-left languages.
 
 This option overrides the setting of environment variable `COLUMNS`.
 
+### -browser [program]
+
+Specify the web browser to use.
+
+This option overrides the setting of environment variable `BROWSER`.
+
 ### -p, -play
 
 Listen to the translation.


### PR DESCRIPTION
We are now supporting two URI schemes:
- `http(s)`
- `file`
### Translate a website

Open a browser session for viewing the translation (in Google Translate):

```
$ trans :zh http://www.apple.com/iphone-6
```

You can also specify the browser to use:

```
$ trans :zh -browser=firefox http://www.apple.com/iphone-6
```
### Translate a file

```
$ trans :zh file://LICENSE
```
