### PR TITLE
Add a new option '--manual'

### DIFF
--- a/build.awk
+++ b/build.awk
@@ -61,6 +61,13 @@ function build(target,    group, inline, line, temp) {
         print "EOF" > Trans
         print "export TRANS_PROGRAM" > Trans
 
+        print "read -r -d '' TRANS_MANPAGE << 'EOF'" > Trans
+        if (fileExists(Man))
+            while (getline line < Man)
+                print line > Trans
+        print "EOF" > Trans
+        print "export TRANS_MANPAGE" > Trans
+
         print "export COLUMNS" > Trans
 
         print "gawk \"$TRANS_PROGRAM\" - \"$@\"" > Trans

--- a/build.awk
+++ b/build.awk
@@ -61,13 +61,6 @@ function build(target,    group, inline, line, temp) {
         print "EOF" > Trans
         print "export TRANS_PROGRAM" > Trans
 
-        print "read -r -d '' TRANS_MANPAGE << 'EOF'" > Trans
-        if (fileExists(Man))
-            while (getline line < Man)
-                print line > Trans
-        print "EOF" > Trans
-        print "export TRANS_MANPAGE" > Trans
-
         print "export COLUMNS" > Trans
 
         print "gawk \"$TRANS_PROGRAM\" - \"$@\"" > Trans

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -84,14 +84,7 @@ BEGIN {
         # -H, -h, -help
         match(ARGV[pos], /^--?(h(e(lp?)?)?|H)$/)
         if (RSTART) {
-            if (ENVIRON["TRANS_MANPAGE"])
-                system("echo -E \"${TRANS_MANPAGE}\" | " \
-                       "groff -Wall -mtty-char -mandoc -Tutf8 -Dutf8 -rLL=${COLUMNS}n -rLT=${COLUMNS}n | " \
-                       (system("most 2>/dev/null") ?
-                        "less -s -P\"\\ \\Manual page " Command "(1) line %lt (press h for help or q to quit)\"" :
-                        "most -Cs"))
-            else
-                print getHelp()
+            print getHelp()
             exit
         }
 

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -88,6 +88,20 @@ BEGIN {
             exit
         }
 
+        # -M, -m, -manual
+        match(ARGV[pos], /^--?(m(a(n(u(al?)?)?)?)?|M)$/)
+        if (RSTART) {
+            if (ENVIRON["TRANS_MANPAGE"])
+                system("echo -E \"${TRANS_MANPAGE}\" | " \
+                       "groff -Wall -mtty-char -mandoc -Tutf8 -Dutf8 -rLL=${COLUMNS}n -rLT=${COLUMNS}n | " \
+                       (system("most 2>/dev/null") ?
+                        "less -s -P\"\\ \\Manual page " Command "(1) line %lt (press h for help or q to quit)\"" :
+                        "most -Cs"))
+            else
+                print getHelp()
+            exit
+        }
+
         # -r, -reference
         match(ARGV[pos], /^--?r(e(f(e(r(e(n(ce?)?)?)?)?)?)?)?$/)
         if (RSTART) {


### PR DESCRIPTION
This changed the behavior of `--help`. From now on, `--help` will always display a simple help message, instead of the detailed man page.
