### PR TITLE
Display dictionary items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,24 @@
 [Translate Shell](http://www.soimort.org/translate-shell) (previously _Google Translate CLI_) is a command-line interface and interactive shell for [Google Translate](https://translate.google.com/). It works just the way you want it to be.
 
 ```
-$ trans "Saluton, Mondo"
-Hello, World
+$ trans 'Saluton, Mondo!'
+Saluton, Mondo!
 
-Translations of Saluton, Mondo
-(Esperanto -> English)
-Saluton(Hello/Hail/Hi/A greeting/Saluton) , Mondo(, World)
+Hello, World!
+
+Translations of Saluton, Mondo!
+[ Esperanto -> English ]
+Saluton ,
+    Hello,
+Mondo !
+    World!
 ```
 
 Translations with detailed explanations are shown by default. You can also translate the text briefly, i.e., only the most relevant translation is shown: (this will give you the same result as in [Google Translate CLI Legacy](https://github.com/soimort/translate-shell/tree/legacy))
 
 ```
-$ trans -b "Saluton, Mondo"
-Hello, World
+$ trans -b 'Saluton, Mondo!'
+Hello, World!
 ```
 
 Translations can be done interactively; input your text line by line:

--- a/include/Commons.awk
+++ b/include/Commons.awk
@@ -248,19 +248,33 @@ function initAnsiCode() {
     AnsiCode["white"]         = "\33[97m"
 }
 
+# Return ANSI escaped string.
+function ansi(code, text) {
+    switch (code) {
+    case "bold":
+        return AnsiCode[code] text AnsiCode["no bold"]
+    case "underline":
+        return AnsiCode[code] text AnsiCode["no underline"]
+    case "negative":
+        return AnsiCode[code] text AnsiCode["positive"]
+    default:
+        return AnsiCode[code] text AnsiCode[0]
+    }
+}
+
 # Print warning message.
 function w(text) {
-    print AnsiCode["yellow"] text AnsiCode[0] > "/dev/stderr"
+    print ansi("yellow", text) > "/dev/stderr"
 }
 
 # Print error message.
 function e(text) {
-    print AnsiCode["red"] AnsiCode["bold"] text AnsiCode[0] > "/dev/stderr"
+    print ansi("red", text) > "/dev/stderr"
 }
 
 # Print debugging message.
 function d(text) {
-    print AnsiCode["gray"] text AnsiCode[0] > "/dev/stderr"
+    print ansi("gray", text) > "/dev/stderr"
 }
 
 # Log an array.

--- a/include/Commons.awk
+++ b/include/Commons.awk
@@ -269,7 +269,7 @@ function w(text) {
 
 # Print error message.
 function e(text) {
-    print ansi("red", text) > "/dev/stderr"
+    print ansi("bold", ansi("red", text)) > "/dev/stderr"
 }
 
 # Print debugging message.

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -95,10 +95,10 @@ function getReference(displayName) {
             Locale["mr"]["name"] "        - " ansi("bold", "mr") "  │ " \
             Locale["yi"]["name"] "    - " ansi("bold", "yi") " │" RS \
             "│ " Locale["de"]["name"] "              - " ansi("bold", "de") "    │ " \
-            Locale["my"]["name"] "        - " ansi("bold", "my") "  │ " \
+            Locale["mn"]["name"] "      - " ansi("bold", "mn") "  │ " \
             Locale["yo"]["name"] "     - " ansi("bold", "yo") " │" RS \
             "│ " Locale["el"]["name"] "               - " ansi("bold", "el") "    │ " \
-            Locale["mn"]["name"] "      - " ansi("bold", "mn") "  │ " \
+            Locale["my"]["name"] "        - " ansi("bold", "my") "  │ " \
             Locale["zu"]["name"] "       - " ansi("bold", "zu") " │" RS \
             "│ " Locale["gu"]["name"] "            - " ansi("bold", "gu") "    │ " \
             Locale["ne"]["name"] "         - " ansi("bold", "ne") "  │ " \

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -12,226 +12,249 @@ function getVersion() {
 #     displayName = "endonym" or "name"
 function getReference(displayName) {
     if (displayName == "name")
-        return "┌─────────────────────────────┬──────────────────────┬─────────────────┐\n" \
-            "│ " Locale["af"]["name"] "           - " AnsiCode["bold"] "af" AnsiCode["no bold"] "    │ " \
-            Locale["ha"]["name"] "          - " AnsiCode["bold"] "ha" AnsiCode["no bold"] "  │ " \
-            Locale["fa"]["name"] "    - " AnsiCode["bold"] "fa" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["sq"]["name"] "            - " AnsiCode["bold"] "sq" AnsiCode["no bold"] "    │ " \
-            Locale["he"]["name"] "         - " AnsiCode["bold"] "he" AnsiCode["no bold"] "  │ " \
-            Locale["pl"]["name"] "     - " AnsiCode["bold"] "pl" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["ar"]["name"] "              - " AnsiCode["bold"] "ar" AnsiCode["no bold"] "    │ " \
-            Locale["hi"]["name"] "          - " AnsiCode["bold"] "hi" AnsiCode["no bold"] "  │ " \
-            Locale["pt"]["name"] " - " AnsiCode["bold"] "pt" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["hy"]["name"] "            - " AnsiCode["bold"] "hy" AnsiCode["no bold"] "    │ " \
-            Locale["hmn"]["name"] "          - " AnsiCode["bold"] "hmn" AnsiCode["no bold"] " │ " \
-            Locale["pa"]["name"] "    - " AnsiCode["bold"] "pa" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["az"]["name"] "         - " AnsiCode["bold"] "az" AnsiCode["no bold"] "    │ " \
-            Locale["hu"]["name"] "      - " AnsiCode["bold"] "hu" AnsiCode["no bold"] "  │ " \
-            Locale["ro"]["name"] "   - " AnsiCode["bold"] "ro" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["eu"]["name"] "              - " AnsiCode["bold"] "eu" AnsiCode["no bold"] "    │ " \
-            Locale["is"]["name"] "      - " AnsiCode["bold"] "is" AnsiCode["no bold"] "  │ " \
-            Locale["ru"]["name"] "    - " AnsiCode["bold"] "ru" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["be"]["name"] "          - " AnsiCode["bold"] "be" AnsiCode["no bold"] "    │ " \
-            Locale["ig"]["name"] "           - " AnsiCode["bold"] "ig" AnsiCode["no bold"] "  │ " \
-            Locale["sr"]["name"] "    - " AnsiCode["bold"] "sr" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["bn"]["name"] "             - " AnsiCode["bold"] "bn" AnsiCode["no bold"] "    │ " \
-            Locale["id"]["name"] "     - " AnsiCode["bold"] "id" AnsiCode["no bold"] "  │ " \
-            Locale["st"]["name"] "    - " AnsiCode["bold"] "st" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["bs"]["name"] "             - " AnsiCode["bold"] "bs" AnsiCode["no bold"] "    │ " \
-            Locale["ga"]["name"] "          - " AnsiCode["bold"] "ga" AnsiCode["no bold"] "  │ " \
-            Locale["si"]["name"] "    - " AnsiCode["bold"] "si" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["bg"]["name"] "           - " AnsiCode["bold"] "bg" AnsiCode["no bold"] "    │ " \
-            Locale["it"]["name"] "        - " AnsiCode["bold"] "it" AnsiCode["no bold"] "  │ " \
-            Locale["sk"]["name"] "     - " AnsiCode["bold"] "sk" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["ca"]["name"] "             - " AnsiCode["bold"] "ca" AnsiCode["no bold"] "    │ " \
-            Locale["ja"]["name"] "       - " AnsiCode["bold"] "ja" AnsiCode["no bold"] "  │ " \
-            Locale["sl"]["name"] "  - " AnsiCode["bold"] "sl" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["ceb"]["name"] "             - " AnsiCode["bold"] "ceb" AnsiCode["no bold"] "   │ " \
-            Locale["jv"]["name"] "       - " AnsiCode["bold"] "jv" AnsiCode["no bold"] "  │ " \
-            Locale["so"]["name"] "     - " AnsiCode["bold"] "so" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["ny"]["name"] "            - " AnsiCode["bold"] "ny" AnsiCode["no bold"] "    │ " \
-            Locale["kn"]["name"] "        - " AnsiCode["bold"] "kn" AnsiCode["no bold"] "  │ " \
-            Locale["es"]["name"] "    - " AnsiCode["bold"] "es" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["zh-CN"]["name"] "  - " AnsiCode["bold"] "zh-CN" AnsiCode["no bold"] " │ " \
-            Locale["kk"]["name"] "         - " AnsiCode["bold"] "kk" AnsiCode["no bold"] "  │ " \
-            Locale["su"]["name"] "  - " AnsiCode["bold"] "su" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["zh-TW"]["name"] " - " AnsiCode["bold"] "zh-TW" AnsiCode["no bold"] " │ " \
-            Locale["km"]["name"] "          - " AnsiCode["bold"] "km" AnsiCode["no bold"] "  │ " \
-            Locale["sw"]["name"] "    - " AnsiCode["bold"] "sw" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["hr"]["name"] "            - " AnsiCode["bold"] "hr" AnsiCode["no bold"] "    │ " \
-            Locale["ko"]["name"] "         - " AnsiCode["bold"] "ko" AnsiCode["no bold"] "  │ " \
-            Locale["sv"]["name"] "    - " AnsiCode["bold"] "sv" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["cs"]["name"] "               - " AnsiCode["bold"] "cs" AnsiCode["no bold"] "    │ " \
-            Locale["lo"]["name"] "            - " AnsiCode["bold"] "lo" AnsiCode["no bold"] "  │ " \
-            Locale["tg"]["name"] "      - " AnsiCode["bold"] "tg" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["da"]["name"] "              - " AnsiCode["bold"] "da" AnsiCode["no bold"] "    │ " \
-            Locale["la"]["name"] "          - " AnsiCode["bold"] "la" AnsiCode["no bold"] "  │ " \
-            Locale["ta"]["name"] "      - " AnsiCode["bold"] "ta" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["nl"]["name"] "               - " AnsiCode["bold"] "nl" AnsiCode["no bold"] "    │ " \
-            Locale["lv"]["name"] "        - " AnsiCode["bold"] "lv" AnsiCode["no bold"] "  │ " \
-            Locale["te"]["name"] "     - " AnsiCode["bold"] "te" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["en"]["name"] "             - " AnsiCode["bold"] "en" AnsiCode["no bold"] "    │ " \
-            Locale["lt"]["name"] "     - " AnsiCode["bold"] "lt" AnsiCode["no bold"] "  │ " \
-            Locale["th"]["name"] "       - " AnsiCode["bold"] "th" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["eo"]["name"] "           - " AnsiCode["bold"] "eo" AnsiCode["no bold"] "    │ " \
-            Locale["mk"]["name"] "     - " AnsiCode["bold"] "mk" AnsiCode["no bold"] "  │ " \
-            Locale["tr"]["name"] "    - " AnsiCode["bold"] "tr" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["et"]["name"] "            - " AnsiCode["bold"] "et" AnsiCode["no bold"] "    │ " \
-            Locale["mg"]["name"] "       - " AnsiCode["bold"] "mg" AnsiCode["no bold"] "  │ " \
-            Locale["uk"]["name"] "  - " AnsiCode["bold"] "uk" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["tl"]["name"] "            - " AnsiCode["bold"] "tl" AnsiCode["no bold"] "    │ " \
-            Locale["ms"]["name"] "          - " AnsiCode["bold"] "ms" AnsiCode["no bold"] "  │ " \
-            Locale["ur"]["name"] "       - " AnsiCode["bold"] "ur" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["fi"]["name"] "             - " AnsiCode["bold"] "fi" AnsiCode["no bold"] "    │ " \
-            Locale["ml"]["name"] "      - " AnsiCode["bold"] "ml" AnsiCode["no bold"] "  │ " \
-            Locale["uz"]["name"] "      - " AnsiCode["bold"] "uz" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["fr"]["name"] "              - " AnsiCode["bold"] "fr" AnsiCode["no bold"] "    │ " \
-            Locale["mt"]["name"] "        - " AnsiCode["bold"] "mt" AnsiCode["no bold"] "  │ " \
-            Locale["vi"]["name"] " - " AnsiCode["bold"] "vi" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["gl"]["name"] "            - " AnsiCode["bold"] "gl" AnsiCode["no bold"] "    │ " \
-            Locale["mi"]["name"] "          - " AnsiCode["bold"] "mi" AnsiCode["no bold"] "  │ " \
-            Locale["cy"]["name"] "      - " AnsiCode["bold"] "cy" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["ka"]["name"] "            - " AnsiCode["bold"] "ka" AnsiCode["no bold"] "    │ " \
-            Locale["mr"]["name"] "        - " AnsiCode["bold"] "mr" AnsiCode["no bold"] "  │ " \
-            Locale["yi"]["name"] "    - " AnsiCode["bold"] "yi" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["de"]["name"] "              - " AnsiCode["bold"] "de" AnsiCode["no bold"] "    │ " \
-            Locale["my"]["name"] "        - " AnsiCode["bold"] "my" AnsiCode["no bold"] "  │ " \
-            Locale["yo"]["name"] "     - " AnsiCode["bold"] "yo" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["el"]["name"] "               - " AnsiCode["bold"] "el" AnsiCode["no bold"] "    │ " \
-            Locale["mn"]["name"] "      - " AnsiCode["bold"] "mn" AnsiCode["no bold"] "  │ " \
-            Locale["zu"]["name"] "       - " AnsiCode["bold"] "zu" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["gu"]["name"] "            - " AnsiCode["bold"] "gu" AnsiCode["no bold"] "    │ " \
-            Locale["ne"]["name"] "         - " AnsiCode["bold"] "ne" AnsiCode["no bold"] "  │ " \
-            "                │\n" \
-            "│ " Locale["ht"]["name"] "      - " AnsiCode["bold"] "ht" AnsiCode["no bold"] "    │ " \
-            Locale["no"]["name"] "      - " AnsiCode["bold"] "no" AnsiCode["no bold"] "  │ " \
-            "                │\n" \
+        return "┌─────────────────────────────┬──────────────────────┬─────────────────┐" RS \
+            "│ " Locale["af"]["name"] "           - " ansi("bold", "af") "    │ " \
+            Locale["ha"]["name"] "          - " ansi("bold", "ha") "  │ " \
+            Locale["fa"]["name"] "    - " ansi("bold", "fa") " │" RS    \
+            "│ " Locale["sq"]["name"] "            - " ansi("bold", "sq") "    │ " \
+            Locale["he"]["name"] "         - " ansi("bold", "he") "  │ " \
+            Locale["pl"]["name"] "     - " ansi("bold", "pl") " │" RS   \
+            "│ " Locale["ar"]["name"] "              - " ansi("bold", "ar") "    │ " \
+            Locale["hi"]["name"] "          - " ansi("bold", "hi") "  │ " \
+            Locale["pt"]["name"] " - " ansi("bold", "pt") " │" RS       \
+            "│ " Locale["hy"]["name"] "            - " ansi("bold", "hy") "    │ " \
+            Locale["hmn"]["name"] "          - " ansi("bold", "hmn") " │ " \
+            Locale["pa"]["name"] "    - " ansi("bold", "pa") " │" RS    \
+            "│ " Locale["az"]["name"] "         - " ansi("bold", "az") "    │ " \
+            Locale["hu"]["name"] "      - " ansi("bold", "hu") "  │ "   \
+            Locale["ro"]["name"] "   - " ansi("bold", "ro") " │" RS     \
+            "│ " Locale["eu"]["name"] "              - " ansi("bold", "eu") "    │ " \
+            Locale["is"]["name"] "      - " ansi("bold", "is") "  │ "   \
+            Locale["ru"]["name"] "    - " ansi("bold", "ru") " │" RS    \
+            "│ " Locale["be"]["name"] "          - " ansi("bold", "be") "    │ " \
+            Locale["ig"]["name"] "           - " ansi("bold", "ig") "  │ " \
+            Locale["sr"]["name"] "    - " ansi("bold", "sr") " │" RS    \
+            "│ " Locale["bn"]["name"] "             - " ansi("bold", "bn") "    │ " \
+            Locale["id"]["name"] "     - " ansi("bold", "id") "  │ "    \
+            Locale["st"]["name"] "    - " ansi("bold", "st") " │" RS    \
+            "│ " Locale["bs"]["name"] "             - " ansi("bold", "bs") "    │ " \
+            Locale["ga"]["name"] "          - " ansi("bold", "ga") "  │ " \
+            Locale["si"]["name"] "    - " ansi("bold", "si") " │" RS    \
+            "│ " Locale["bg"]["name"] "           - " ansi("bold", "bg") "    │ " \
+            Locale["it"]["name"] "        - " ansi("bold", "it") "  │ " \
+            Locale["sk"]["name"] "     - " ansi("bold", "sk") " │" RS   \
+            "│ " Locale["ca"]["name"] "             - " ansi("bold", "ca") "    │ " \
+            Locale["ja"]["name"] "       - " ansi("bold", "ja") "  │ "  \
+            Locale["sl"]["name"] "  - " ansi("bold", "sl") " │" RS      \
+            "│ " Locale["ceb"]["name"] "             - " ansi("bold", "ceb") "   │ " \
+            Locale["jv"]["name"] "       - " ansi("bold", "jv") "  │ "  \
+            Locale["so"]["name"] "     - " ansi("bold", "so") " │" RS   \
+            "│ " Locale["ny"]["name"] "            - " ansi("bold", "ny") "    │ " \
+            Locale["kn"]["name"] "        - " ansi("bold", "kn") "  │ " \
+            Locale["es"]["name"] "    - " ansi("bold", "es") " │" RS    \
+            "│ " Locale["zh-CN"]["name"] "  - " ansi("bold", "zh-CN") " │ " \
+            Locale["kk"]["name"] "         - " ansi("bold", "kk") "  │ " \
+            Locale["su"]["name"] "  - " ansi("bold", "su") " │" RS      \
+            "│ " Locale["zh-TW"]["name"] " - " ansi("bold", "zh-TW") " │ " \
+            Locale["km"]["name"] "          - " ansi("bold", "km") "  │ " \
+            Locale["sw"]["name"] "    - " ansi("bold", "sw") " │" RS    \
+            "│ " Locale["hr"]["name"] "            - " ansi("bold", "hr") "    │ " \
+            Locale["ko"]["name"] "         - " ansi("bold", "ko") "  │ " \
+            Locale["sv"]["name"] "    - " ansi("bold", "sv") " │" RS    \
+            "│ " Locale["cs"]["name"] "               - " ansi("bold", "cs") "    │ " \
+            Locale["lo"]["name"] "            - " ansi("bold", "lo") "  │ " \
+            Locale["tg"]["name"] "      - " ansi("bold", "tg") " │" RS  \
+            "│ " Locale["da"]["name"] "              - " ansi("bold", "da") "    │ " \
+            Locale["la"]["name"] "          - " ansi("bold", "la") "  │ " \
+            Locale["ta"]["name"] "      - " ansi("bold", "ta") " │" RS \
+            "│ " Locale["nl"]["name"] "               - " ansi("bold", "nl") "    │ " \
+            Locale["lv"]["name"] "        - " ansi("bold", "lv") "  │ " \
+            Locale["te"]["name"] "     - " ansi("bold", "te") " │" RS   \
+            "│ " Locale["en"]["name"] "             - " ansi("bold", "en") "    │ " \
+            Locale["lt"]["name"] "     - " ansi("bold", "lt") "  │ "    \
+            Locale["th"]["name"] "       - " ansi("bold", "th") " │" RS \
+            "│ " Locale["eo"]["name"] "           - " ansi("bold", "eo") "    │ " \
+            Locale["mk"]["name"] "     - " ansi("bold", "mk") "  │ "    \
+            Locale["tr"]["name"] "    - " ansi("bold", "tr") " │" RS    \
+            "│ " Locale["et"]["name"] "            - " ansi("bold", "et") "    │ " \
+            Locale["mg"]["name"] "       - " ansi("bold", "mg") "  │ " \
+            Locale["uk"]["name"] "  - " ansi("bold", "uk") " │" RS      \
+            "│ " Locale["tl"]["name"] "            - " ansi("bold", "tl") "    │ " \
+            Locale["ms"]["name"] "          - " ansi("bold", "ms") "  │ " \
+            Locale["ur"]["name"] "       - " ansi("bold", "ur") " │" RS \
+            "│ " Locale["fi"]["name"] "             - " ansi("bold", "fi") "    │ " \
+            Locale["ml"]["name"] "      - " ansi("bold", "ml") "  │ " \
+            Locale["uz"]["name"] "      - " ansi("bold", "uz") " │" RS \
+            "│ " Locale["fr"]["name"] "              - " ansi("bold", "fr") "    │ " \
+            Locale["mt"]["name"] "        - " ansi("bold", "mt") "  │ " \
+            Locale["vi"]["name"] " - " ansi("bold", "vi") " │" RS \
+            "│ " Locale["gl"]["name"] "            - " ansi("bold", "gl") "    │ " \
+            Locale["mi"]["name"] "          - " ansi("bold", "mi") "  │ " \
+            Locale["cy"]["name"] "      - " ansi("bold", "cy") " │" RS \
+            "│ " Locale["ka"]["name"] "            - " ansi("bold", "ka") "    │ " \
+            Locale["mr"]["name"] "        - " ansi("bold", "mr") "  │ " \
+            Locale["yi"]["name"] "    - " ansi("bold", "yi") " │" RS \
+            "│ " Locale["de"]["name"] "              - " ansi("bold", "de") "    │ " \
+            Locale["my"]["name"] "        - " ansi("bold", "my") "  │ " \
+            Locale["yo"]["name"] "     - " ansi("bold", "yo") " │" RS \
+            "│ " Locale["el"]["name"] "               - " ansi("bold", "el") "    │ " \
+            Locale["mn"]["name"] "      - " ansi("bold", "mn") "  │ " \
+            Locale["zu"]["name"] "       - " ansi("bold", "zu") " │" RS \
+            "│ " Locale["gu"]["name"] "            - " ansi("bold", "gu") "    │ " \
+            Locale["ne"]["name"] "         - " ansi("bold", "ne") "  │ " \
+            "                │" RS \
+            "│ " Locale["ht"]["name"] "      - " ansi("bold", "ht") "    │ " \
+            Locale["no"]["name"] "      - " ansi("bold", "no") "  │ " \
+            "                │" RS \
             "└─────────────────────────────┴──────────────────────┴─────────────────┘"
     else
-        return "┌──────────────────────┬───────────────────────┬─────────────────────┐\n" \
-            "│ " Locale["af"]["display"] "      - " AnsiCode["bold"] "af" AnsiCode["no bold"] "  │ " \
-            Locale["hu"]["display"] "           - " AnsiCode["bold"] "hu" AnsiCode["no bold"] " │ " \
-            Locale["pl"]["display"] "      - " AnsiCode["bold"] "pl" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["ar"]["display"] "        - " AnsiCode["bold"] "ar" AnsiCode["no bold"] "  │ " \
-            Locale["hy"]["display"] "          - " AnsiCode["bold"] "hy" AnsiCode["no bold"] " │ " \
-            Locale["pt"]["display"] "   - " AnsiCode["bold"] "pt" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["az"]["display"] "   - " AnsiCode["bold"] "az" AnsiCode["no bold"] "  │ " \
-            Locale["id"]["display"] " - " AnsiCode["bold"] "id" AnsiCode["no bold"] " │ " \
-            Locale["ro"]["display"] "      - " AnsiCode["bold"] "ro" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["be"]["display"] "     - " AnsiCode["bold"] "be" AnsiCode["no bold"] "  │ " \
-            Locale["ig"]["display"] "             - " AnsiCode["bold"] "ig" AnsiCode["no bold"] " │ " \
-            Locale["ru"]["display"] "     - " AnsiCode["bold"] "ru" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["bg"]["display"] "      - " AnsiCode["bold"] "bg" AnsiCode["no bold"] "  │ " \
-            Locale["is"]["display"] "         - " AnsiCode["bold"] "is" AnsiCode["no bold"] " │ " \
-            Locale["si"]["display"] "        - " AnsiCode["bold"] "si" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["bn"]["display"] "          - " AnsiCode["bold"] "bn" AnsiCode["no bold"] "  │ " \
-            Locale["it"]["display"] "         - " AnsiCode["bold"] "it" AnsiCode["no bold"] " │ " \
-            Locale["sk"]["display"] "  - " AnsiCode["bold"] "sk" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["bs"]["display"] "       - " AnsiCode["bold"] "bs" AnsiCode["no bold"] "  │ " \
-            Locale["ja"]["display"] "           - " AnsiCode["bold"] "ja" AnsiCode["no bold"] " │ " \
-            Locale["sl"]["display"] " - " AnsiCode["bold"] "sl" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["ca"]["display"] "         - " AnsiCode["bold"] "ca" AnsiCode["no bold"] "  │ " \
-            Locale["jv"]["display"] "        - " AnsiCode["bold"] "jv" AnsiCode["no bold"] " │ " \
-            Locale["so"]["display"] "    - " AnsiCode["bold"] "so" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["ceb"]["display"] "        - " AnsiCode["bold"] "ceb" AnsiCode["no bold"] " │ " \
-            Locale["ka"]["display"] "          - " AnsiCode["bold"] "ka" AnsiCode["no bold"] " │ " \
-            Locale["sq"]["display"] "       - " AnsiCode["bold"] "sq" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["cs"]["display"] "        - " AnsiCode["bold"] "cs" AnsiCode["no bold"] "  │ " \
-            Locale["kk"]["display"] "       - " AnsiCode["bold"] "kk" AnsiCode["no bold"] " │ " \
-            Locale["sr"]["display"] "      - " AnsiCode["bold"] "sr" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["cy"]["display"] "        - " AnsiCode["bold"] "cy" AnsiCode["no bold"] "  │ " \
-            Locale["km"]["display"] "         - " AnsiCode["bold"] "km" AnsiCode["no bold"] " │ " \
-            Locale["st"]["display"] "     - " AnsiCode["bold"] "st" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["da"]["display"] "          - " AnsiCode["bold"] "da" AnsiCode["no bold"] "  │ " \
-            Locale["kn"]["display"] "             - " AnsiCode["bold"] "kn" AnsiCode["no bold"] " │ " \
-            Locale["su"]["display"] "  - " AnsiCode["bold"] "su" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["de"]["display"] "        - " AnsiCode["bold"] "de" AnsiCode["no bold"] "  │ " \
-            Locale["ko"]["display"] "           - " AnsiCode["bold"] "ko" AnsiCode["no bold"] " │ " \
-            Locale["sv"]["display"] "     - " AnsiCode["bold"] "sv" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["el"]["display"] "       - " AnsiCode["bold"] "el" AnsiCode["no bold"] "  │ " \
-            Locale["la"]["display"] "           - " AnsiCode["bold"] "la" AnsiCode["no bold"] " │ " \
-            Locale["sw"]["display"] "   - " AnsiCode["bold"] "sw" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["en"]["display"] "        - " AnsiCode["bold"] "en" AnsiCode["no bold"] "  │ " \
-            Locale["lo"]["display"] "              - " AnsiCode["bold"] "lo" AnsiCode["no bold"] " │ " \
-            Locale["ta"]["display"] "        - " AnsiCode["bold"] "ta" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["eo"]["display"] "      - " AnsiCode["bold"] "eo" AnsiCode["no bold"] "  │ " \
-            Locale["lt"]["display"] "         - " AnsiCode["bold"] "lt" AnsiCode["no bold"] " │ " \
-            Locale["te"]["display"] "       - " AnsiCode["bold"] "te" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["es"]["display"] "        - " AnsiCode["bold"] "es" AnsiCode["no bold"] "  │ " \
-            Locale["lv"]["display"] "         - " AnsiCode["bold"] "lv" AnsiCode["no bold"] " │ " \
-            Locale["tg"]["display"] "      - " AnsiCode["bold"] "tg" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["et"]["display"] "          - " AnsiCode["bold"] "et" AnsiCode["no bold"] "  │ " \
-            Locale["mg"]["display"] "         - " AnsiCode["bold"] "mg" AnsiCode["no bold"] " │ " \
-            Locale["th"]["display"] "         - " AnsiCode["bold"] "th" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["eu"]["display"] "        - " AnsiCode["bold"] "eu" AnsiCode["no bold"] "  │ " \
-            Locale["mi"]["display"] "            - " AnsiCode["bold"] "mi" AnsiCode["no bold"] " │ " \
-            Locale["tl"]["display"] "     - " AnsiCode["bold"] "tl" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["fa"]["display"] "          - " AnsiCode["bold"] "fa" AnsiCode["no bold"] "  │ " \
-            Locale["mk"]["display"] "       - " AnsiCode["bold"] "mk" AnsiCode["no bold"] " │ " \
-            Locale["tr"]["display"] "      - " AnsiCode["bold"] "tr" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["fi"]["display"] "          - " AnsiCode["bold"] "fi" AnsiCode["no bold"] "  │ " \
-            Locale["ml"]["display"] "           - " AnsiCode["bold"] "ml" AnsiCode["no bold"] " │ " \
-            Locale["uk"]["display"] "  - " AnsiCode["bold"] "uk" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["fr"]["display"] "       - " AnsiCode["bold"] "fr" AnsiCode["no bold"] "  │ " \
-            Locale["mn"]["display"] "           - " AnsiCode["bold"] "mn" AnsiCode["no bold"] " │ " \
-            Locale["ur"]["display"] "        - " AnsiCode["bold"] "ur" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["ga"]["display"] "        - " AnsiCode["bold"] "ga" AnsiCode["no bold"] "  │ " \
-            Locale["mr"]["display"] "            - " AnsiCode["bold"] "mr" AnsiCode["no bold"] " │ " \
-            Locale["uz"]["display"] " - " AnsiCode["bold"] "uz" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["gl"]["display"] "         - " AnsiCode["bold"] "gl" AnsiCode["no bold"] "  │ " \
-            Locale["ms"]["display"] "    - " AnsiCode["bold"] "ms" AnsiCode["no bold"] " │ " \
-            Locale["vi"]["display"] "  - " AnsiCode["bold"] "vi" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["gu"]["display"] "         - " AnsiCode["bold"] "gu" AnsiCode["no bold"] "  │ " \
-            Locale["mt"]["display"] "            - " AnsiCode["bold"] "mt" AnsiCode["no bold"] " │ " \
-            Locale["yi"]["display"] "       - " AnsiCode["bold"] "yi" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["ha"]["display"] "          - " AnsiCode["bold"] "ha" AnsiCode["no bold"] "  │ " \
-            Locale["my"]["display"] "          - " AnsiCode["bold"] "my" AnsiCode["no bold"] " │ " \
-            Locale["yo"]["display"] "      - " AnsiCode["bold"] "yo" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["he"]["display"] "          - " AnsiCode["bold"] "he" AnsiCode["no bold"] "  │ " \
-            Locale["ne"]["display"] "            - " AnsiCode["bold"] "ne" AnsiCode["no bold"] " │ " \
-            Locale["zh-CN"]["display"] "    - " AnsiCode["bold"] "zh-CN" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["hi"]["display"] "          - " AnsiCode["bold"] "hi" AnsiCode["no bold"] "  │ " \
-            Locale["nl"]["display"] "       - " AnsiCode["bold"] "nl" AnsiCode["no bold"] " │ " \
-            Locale["zh-TW"]["display"] "    - " AnsiCode["bold"] "zh-TW" AnsiCode["no bold"] " │\n" \
-            "│ " Locale["hmn"]["display"] "          - " AnsiCode["bold"] "hmn" AnsiCode["no bold"] " │ " \
-            Locale["no"]["display"] "            - " AnsiCode["bold"] "no" AnsiCode["no bold"] " │ " \
-            Locale["zu"]["display"] "     - " AnsiCode["bold"] "zu" AnsiCode["no bold"] "    │\n" \
-            "│ " Locale["hr"]["display"] "       - " AnsiCode["bold"] "hr" AnsiCode["no bold"] "  │ " \
-            Locale["ny"]["display"] "           - " AnsiCode["bold"] "ny" AnsiCode["no bold"] " │ " \
-            "                    │\n" \
-            "│ " Locale["ht"]["display"] " - " AnsiCode["bold"] "ht" AnsiCode["no bold"] "  │ " \
-            Locale["pa"]["display"] "            - " AnsiCode["bold"] "pa" AnsiCode["no bold"] " │ " \
-            "                    │\n" \
+        return "┌──────────────────────┬───────────────────────┬─────────────────────┐" RS \
+            "│ " Locale["af"]["display"] "      - " ansi("bold", "af") "  │ " \
+            Locale["hu"]["display"] "           - " ansi("bold", "hu") " │ " \
+            Locale["pl"]["display"] "      - " ansi("bold", "pl") "    │" RS \
+            "│ " Locale["ar"]["display"] "        - " ansi("bold", "ar") "  │ " \
+            Locale["hy"]["display"] "          - " ansi("bold", "hy") " │ " \
+            Locale["pt"]["display"] "   - " ansi("bold", "pt") "    │" RS \
+            "│ " Locale["az"]["display"] "   - " ansi("bold", "az") "  │ " \
+            Locale["id"]["display"] " - " ansi("bold", "id") " │ " \
+            Locale["ro"]["display"] "      - " ansi("bold", "ro") "    │" RS \
+            "│ " Locale["be"]["display"] "     - " ansi("bold", "be") "  │ " \
+            Locale["ig"]["display"] "             - " ansi("bold", "ig") " │ " \
+            Locale["ru"]["display"] "     - " ansi("bold", "ru") "    │" RS \
+            "│ " Locale["bg"]["display"] "      - " ansi("bold", "bg") "  │ " \
+            Locale["is"]["display"] "         - " ansi("bold", "is") " │ " \
+            Locale["si"]["display"] "        - " ansi("bold", "si") "    │" RS \
+            "│ " Locale["bn"]["display"] "          - " ansi("bold", "bn") "  │ " \
+            Locale["it"]["display"] "         - " ansi("bold", "it") " │ " \
+            Locale["sk"]["display"] "  - " ansi("bold", "sk") "    │" RS \
+            "│ " Locale["bs"]["display"] "       - " ansi("bold", "bs") "  │ " \
+            Locale["ja"]["display"] "           - " ansi("bold", "ja") " │ " \
+            Locale["sl"]["display"] " - " ansi("bold", "sl") "    │" RS \
+            "│ " Locale["ca"]["display"] "         - " ansi("bold", "ca") "  │ " \
+            Locale["jv"]["display"] "        - " ansi("bold", "jv") " │ " \
+            Locale["so"]["display"] "    - " ansi("bold", "so") "    │" RS \
+            "│ " Locale["ceb"]["display"] "        - " ansi("bold", "ceb") " │ " \
+            Locale["ka"]["display"] "          - " ansi("bold", "ka") " │ " \
+            Locale["sq"]["display"] "       - " ansi("bold", "sq") "    │" RS \
+            "│ " Locale["cs"]["display"] "        - " ansi("bold", "cs") "  │ " \
+            Locale["kk"]["display"] "       - " ansi("bold", "kk") " │ " \
+            Locale["sr"]["display"] "      - " ansi("bold", "sr") "    │" RS \
+            "│ " Locale["cy"]["display"] "        - " ansi("bold", "cy") "  │ " \
+            Locale["km"]["display"] "         - " ansi("bold", "km") " │ " \
+            Locale["st"]["display"] "     - " ansi("bold", "st") "    │" RS \
+            "│ " Locale["da"]["display"] "          - " ansi("bold", "da") "  │ " \
+            Locale["kn"]["display"] "             - " ansi("bold", "kn") " │ " \
+            Locale["su"]["display"] "  - " ansi("bold", "su") "    │" RS \
+            "│ " Locale["de"]["display"] "        - " ansi("bold", "de") "  │ " \
+            Locale["ko"]["display"] "           - " ansi("bold", "ko") " │ " \
+            Locale["sv"]["display"] "     - " ansi("bold", "sv") "    │" RS \
+            "│ " Locale["el"]["display"] "       - " ansi("bold", "el") "  │ " \
+            Locale["la"]["display"] "           - " ansi("bold", "la") " │ " \
+            Locale["sw"]["display"] "   - " ansi("bold", "sw") "    │" RS \
+            "│ " Locale["en"]["display"] "        - " ansi("bold", "en") "  │ " \
+            Locale["lo"]["display"] "              - " ansi("bold", "lo") " │ " \
+            Locale["ta"]["display"] "        - " ansi("bold", "ta") "    │" RS \
+            "│ " Locale["eo"]["display"] "      - " ansi("bold", "eo") "  │ " \
+            Locale["lt"]["display"] "         - " ansi("bold", "lt") " │ " \
+            Locale["te"]["display"] "       - " ansi("bold", "te") "    │" RS \
+            "│ " Locale["es"]["display"] "        - " ansi("bold", "es") "  │ " \
+            Locale["lv"]["display"] "         - " ansi("bold", "lv") " │ " \
+            Locale["tg"]["display"] "      - " ansi("bold", "tg") "    │" RS \
+            "│ " Locale["et"]["display"] "          - " ansi("bold", "et") "  │ " \
+            Locale["mg"]["display"] "         - " ansi("bold", "mg") " │ " \
+            Locale["th"]["display"] "         - " ansi("bold", "th") "    │" RS \
+            "│ " Locale["eu"]["display"] "        - " ansi("bold", "eu") "  │ " \
+            Locale["mi"]["display"] "            - " ansi("bold", "mi") " │ " \
+            Locale["tl"]["display"] "     - " ansi("bold", "tl") "    │" RS \
+            "│ " Locale["fa"]["display"] "          - " ansi("bold", "fa") "  │ " \
+            Locale["mk"]["display"] "       - " ansi("bold", "mk") " │ " \
+            Locale["tr"]["display"] "      - " ansi("bold", "tr") "    │" RS \
+            "│ " Locale["fi"]["display"] "          - " ansi("bold", "fi") "  │ " \
+            Locale["ml"]["display"] "           - " ansi("bold", "ml") " │ " \
+            Locale["uk"]["display"] "  - " ansi("bold", "uk") "    │" RS \
+            "│ " Locale["fr"]["display"] "       - " ansi("bold", "fr") "  │ " \
+            Locale["mn"]["display"] "           - " ansi("bold", "mn") " │ " \
+            Locale["ur"]["display"] "        - " ansi("bold", "ur") "    │" RS \
+            "│ " Locale["ga"]["display"] "        - " ansi("bold", "ga") "  │ " \
+            Locale["mr"]["display"] "            - " ansi("bold", "mr") " │ " \
+            Locale["uz"]["display"] " - " ansi("bold", "uz") "    │" RS \
+            "│ " Locale["gl"]["display"] "         - " ansi("bold", "gl") "  │ " \
+            Locale["ms"]["display"] "    - " ansi("bold", "ms") " │ " \
+            Locale["vi"]["display"] "  - " ansi("bold", "vi") "    │" RS \
+            "│ " Locale["gu"]["display"] "         - " ansi("bold", "gu") "  │ " \
+            Locale["mt"]["display"] "            - " ansi("bold", "mt") " │ " \
+            Locale["yi"]["display"] "       - " ansi("bold", "yi") "    │" RS \
+            "│ " Locale["ha"]["display"] "          - " ansi("bold", "ha") "  │ " \
+            Locale["my"]["display"] "          - " ansi("bold", "my") " │ " \
+            Locale["yo"]["display"] "      - " ansi("bold", "yo") "    │" RS \
+            "│ " Locale["he"]["display"] "          - " ansi("bold", "he") "  │ " \
+            Locale["ne"]["display"] "            - " ansi("bold", "ne") " │ " \
+            Locale["zh-CN"]["display"] "    - " ansi("bold", "zh-CN") " │" RS \
+            "│ " Locale["hi"]["display"] "          - " ansi("bold", "hi") "  │ " \
+            Locale["nl"]["display"] "       - " ansi("bold", "nl") " │ " \
+            Locale["zh-TW"]["display"] "    - " ansi("bold", "zh-TW") " │" RS \
+            "│ " Locale["hmn"]["display"] "          - " ansi("bold", "hmn") " │ " \
+            Locale["no"]["display"] "            - " ansi("bold", "no") " │ " \
+            Locale["zu"]["display"] "     - " ansi("bold", "zu") "    │" RS \
+            "│ " Locale["hr"]["display"] "       - " ansi("bold", "hr") "  │ " \
+            Locale["ny"]["display"] "           - " ansi("bold", "ny") " │ " \
+            "                    │" RS \
+            "│ " Locale["ht"]["display"] " - " ansi("bold", "ht") "  │ " \
+            Locale["pa"]["display"] "            - " ansi("bold", "pa") " │ " \
+            "                    │" RS \
             "└──────────────────────┴───────────────────────┴─────────────────────┘"
 }
 
 # Return help message as a string.
 function getHelp() {
-    return "Usage: " Command " [options] [source]:[target] [" AnsiCode["underline"] "text" AnsiCode["no underline"] "] ...\n" \
-        "       " Command " [options] [source]:[target1]+[target2]+... [" AnsiCode["underline"] "text" AnsiCode["no underline"] "] ...\n\n" \
-        "Options:\n" \
-        "  " AnsiCode["bold"] "-V, -version" AnsiCode["no bold"] "\n    Print version and exit.\n" \
-        "  " AnsiCode["bold"] "-H, -h, -help" AnsiCode["no bold"] "\n    Print this help message and exit.\n" \
-        "  " AnsiCode["bold"] "-M, -m, -manual" AnsiCode["no bold"] "\n    Show the manual.\n" \
-        "  " AnsiCode["bold"] "-r, -reference" AnsiCode["no bold"] "\n    Print a list of languages (displayed in endonyms) and their ISO 639 codes for reference, and exit.\n" \
-        "  " AnsiCode["bold"] "-R, -reference-english" AnsiCode["no bold"] "\n    Print a list of languages (displayed in English names) and their ISO 639 codes for reference, and exit.\n" \
-        "  " AnsiCode["bold"] "-v, -verbose" AnsiCode["no bold"] "\n    Verbose mode. (default)\n" \
-        "  " AnsiCode["bold"] "-b, -brief" AnsiCode["no bold"] "\n    Brief mode.\n" \
-        "  " AnsiCode["bold"] "-no-ansi" AnsiCode["no bold"] "\n    Don't use ANSI escape codes in the translation.\n" \
-        "  " AnsiCode["bold"] "-w [num], -width [num]" AnsiCode["no bold"] "\n    Specify the screen width for padding when displaying right-to-left languages.\n" \
-        "  " AnsiCode["bold"] "-browser [program]" AnsiCode["no bold"] "\n    Specify the web browser to use.\n" \
-        "  " AnsiCode["bold"] "-p, -play" AnsiCode["no bold"] "\n    Listen to the translation.\n" \
-        "  " AnsiCode["bold"] "-player [program]" AnsiCode["no bold"] "\n    Specify the command-line audio player to use, and listen to the translation.\n" \
-        "  " AnsiCode["bold"] "-x [proxy], -proxy [proxy]" AnsiCode["no bold"] "\n    Use proxy on given port.\n" \
-        "  " AnsiCode["bold"] "-I, -interactive" AnsiCode["no bold"] "\n    Start an interactive shell, invoking `rlwrap` whenever possible (unless `-no-rlwrap` is specified).\n" \
-        "  " AnsiCode["bold"] "-no-rlwrap" AnsiCode["no bold"] "\n    Don't invoke `rlwrap` when starting an interactive shell with `-I`.\n" \
-        "  " AnsiCode["bold"] "-E, -emacs" AnsiCode["no bold"] "\n    Start an interactive shell within GNU Emacs, invoking `emacs`.\n" \
-        "  " AnsiCode["bold"] "-prompt [prompt_string]" AnsiCode["no bold"] "\n    Customize your prompt string in the interactive shell.\n" \
-        "  " AnsiCode["bold"] "-prompt-color [color_code]" AnsiCode["no bold"] "\n    Customize your prompt color in the interactive shell.\n" \
-        "  " AnsiCode["bold"] "-i [file], -input [file]" AnsiCode["no bold"] "\n    Specify the input file name.\n" \
-        "  " AnsiCode["bold"] "-o [file], -output [file]" AnsiCode["no bold"] "\n    Specify the output file name.\n" \
-        "  " AnsiCode["bold"] "-l [code], -lang [code]" AnsiCode["no bold"] "\n    Specify your own, native language (\"home/host language\").\n" \
-        "  " AnsiCode["bold"] "-s [code], -source [code]" AnsiCode["no bold"] "\n    Specify the source language (language of the original text).\n" \
-        "  " AnsiCode["bold"] "-t [codes], -target [codes]" AnsiCode["no bold"] "\n    Specify the target language(s) (language(s) of the translated text).\n" \
-        "\nSee the man page " Command "(1) for more information."
+    return "Usage:\t" Command " [options] [source]:[target] [" ansi("underline", "text") "] ..." RS \
+        "\t" Command " [options] [source]:[target1]+[target2]+... [" ansi("underline", "text") "] ..." RS RS \
+        "Options:" RS                                                   \
+        I ansi("bold", "-V, -version") RS                               \
+        I I "Print version and exit." RS                                \
+        I ansi("bold", "-H, -h, -help") RS                              \
+        I I "Print this help message and exit." RS                      \
+        I ansi("bold", "-M, -m, -manual") RS                            \
+        I I "Show the manual." RS                                       \
+        I ansi("bold", "-r, -reference") RS                             \
+        I I "Print a list of languages (displayed in endonyms) and their ISO 639 codes for reference, and exit." RS \
+        I ansi("bold", "-R, -reference-english") RS                     \
+        I I "Print a list of languages (displayed in English names) and their ISO 639 codes for reference, and exit." RS \
+        I ansi("bold", "-v, -verbose") RS                               \
+        I I "Verbose mode. (default)" RS                                \
+        I ansi("bold", "-b, -brief") RS                                 \
+        I I "Brief mode." RS                                            \
+        I ansi("bold", "-no-ansi") RS                                   \
+        I I "Don't use ANSI escape codes in the translation." RS        \
+        I ansi("bold", "-w [num], -width [num]") RS                     \
+        I I "Specify the screen width for padding when displaying right-to-left languages." RS \
+        I ansi("bold", "-browser [program]") RS                         \
+        I I "Specify the web browser to use." RS                        \
+        I ansi("bold", "-p, -play") RS                                  \
+        I I "Listen to the translation." RS                             \
+        I ansi("bold", "-player [program]") RS                          \
+        I I "Specify the command-line audio player to use, and listen to the translation." RS \
+        I ansi("bold", "-x [proxy], -proxy [proxy]") RS                 \
+        I I "Use proxy on given port." RS                               \
+        I ansi("bold", "-I, -interactive") RS                           \
+        I I "Start an interactive shell, invoking `rlwrap` whenever possible (unless `-no-rlwrap` is specified)." RS \
+        I ansi("bold", "-no-rlwrap") RS                                 \
+        I I "Don't invoke `rlwrap` when starting an interactive shell with `-I`." RS \
+        I ansi("bold", "-E, -emacs") RS                                 \
+        I I "Start an interactive shell within GNU Emacs, invoking `emacs`." RS \
+        I ansi("bold", "-prompt [prompt_string]") RS                    \
+        I I "Customize your prompt string in the interactive shell." RS \
+        I ansi("bold", "-prompt-color [color_code]") RS                 \
+        I I "Customize your prompt color in the interactive shell." RS  \
+        I ansi("bold", "-i [file], -input [file]") RS                   \
+        I I "Specify the input file name." RS                           \
+        I ansi("bold", "-o [file], -output [file]") RS                  \
+        I I "Specify the output file name." RS                          \
+        I ansi("bold", "-l [code], -lang [code]") RS                    \
+        I I "Specify your own, native language (\"home/host language\")." RS \
+        I ansi("bold", "-s [code], -source [code]") RS                  \
+        I I "Specify the source language (language of the original text)." RS \
+        I ansi("bold", "-t [codes], -target [codes]") RS                \
+        I I "Specify the target language(s) (language(s) of the translated text)." RS RS \
+        "See the man page " Command "(1) for more information."
 }

--- a/include/Languages.awk
+++ b/include/Languages.awk
@@ -2,497 +2,1295 @@
 # Languages.awk                                                    #
 ####################################################################
 
-# Initialize all supported locales.
-# Mostly ISO 639-1 codes, with a few ISO 639-2 codes (alpha-3).
+# Initialize all locales supported on Google Translate.
+# Mostly ISO 639-1 codes, with a few ISO 639-3 codes.
+# "family" : Language family (from Glottolog)
+# "iso"    : ISO 639-3 code
+# "glotto" : Glottocode
+# "script" : Writing system (ISO 15924 script code)
 # See: <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>
-#      <http://www.loc.gov/standards/iso639-2/php/code_list.php>
+#      <https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes>
+#      <https://en.wikipedia.org/wiki/ISO_15924#List_of_codes>
+#      <http://glottolog.org/>
 function initLocale() {
 
     #1 Afrikaans
-    Locale["af"]["name"]       = "Afrikaans"
-    Locale["af"]["endonym"]    = "Afrikaans"
-    Locale["af"]["message"]    = "Vertalings van %s"
+    Locale["af"]["name"]               = "Afrikaans"
+    Locale["af"]["endonym"]            = "Afrikaans"
+    Locale["af"]["translations-of"]    = "Vertalings van %s"
+    Locale["af"]["definitions-of"]     = "Definisies van %s"
+    Locale["af"]["synonyms"]           = "Sinonieme"
+    Locale["af"]["examples"]           = "Voorbeelde"
+    Locale["af"]["see-also"]           = "Sien ook"
+    Locale["af"]["family"]             = "Indo-European"
+    Locale["af"]["iso"]                = "afr"
+    Locale["af"]["glotto"]             = "afri1274"
+    Locale["af"]["script"]             = "Latn"
 
     #2 Albanian
-    Locale["sq"]["name"]       = "Albanian"
-    Locale["sq"]["endonym"]    = "Shqip"
-    Locale["sq"]["message"]    = "Përkthimet e %s"
+    Locale["sq"]["name"]               = "Albanian"
+    Locale["sq"]["endonym"]            = "Shqip"
+    Locale["sq"]["translations-of"]    = "Përkthimet e %s"
+    Locale["sq"]["definitions-of"]     = "Përkufizime të %s"
+    Locale["sq"]["synonyms"]           = "Sinonime"
+    Locale["sq"]["examples"]           = "Shembuj"
+    Locale["sq"]["see-also"]           = "Shihni gjithashtu"
+    Locale["sq"]["family"]             = "Indo-European"
+    Locale["sq"]["iso"]                = "sqi"
+    Locale["sq"]["glotto"]             = "alba1267"
+    Locale["sq"]["script"]             = "Latn"
 
     #3 Arabic
-    Locale["ar"]["name"]       = "Arabic"
-    Locale["ar"]["endonym"]    = "العربية"
-    Locale["ar"]["message"]    = "ترجمات %s"
-    Locale["ar"]["rtl"]        = "true" # RTL language
+    Locale["ar"]["name"]               = "Arabic"
+    Locale["ar"]["endonym"]            = "العربية"
+    Locale["ar"]["translations-of"]    = "ترجمات %s"
+    Locale["ar"]["definitions-of"]     = "تعريفات %s"
+    Locale["ar"]["synonyms"]           = "مرادفات"
+    Locale["ar"]["examples"]           = "أمثلة"
+    Locale["ar"]["see-also"]           = "انظر أيضًا"
+    Locale["ar"]["family"]             = "Afro-Asiatic"
+    Locale["ar"]["iso"]                = "ara"
+    Locale["ar"]["glotto"]             = "arab1395"
+    Locale["ar"]["script"]             = "Arab"
+    Locale["ar"]["rtl"]                = "true" # RTL language
 
     #4 Armenian
-    Locale["hy"]["name"]       = "Armenian"
-    Locale["hy"]["endonym"]    = "Հայերեն"
-    Locale["hy"]["message"]    = "%s-ի թարգմանությունները"
+    Locale["hy"]["name"]               = "Armenian"
+    Locale["hy"]["endonym"]            = "Հայերեն"
+    Locale["hy"]["translations-of"]    = "%s-ի թարգմանությունները"
+    Locale["hy"]["definitions-of"]     = "%s-ի սահմանումները"
+    Locale["hy"]["synonyms"]           = "Հոմանիշներ"
+    Locale["hy"]["examples"]           = "Օրինակներ"
+    Locale["hy"]["see-also"]           = "Տես նաև"
+    Locale["hy"]["family"]             = "Indo-European"
+    Locale["hy"]["iso"]                = "hye"
+    Locale["hy"]["glotto"]             = "arme1241"
+    Locale["hy"]["script"]             = "Armn"
 
     #5 Azerbaijani
-    Locale["az"]["name"]       = "Azerbaijani"
-    Locale["az"]["endonym"]    = "Azərbaycanca"
-    Locale["az"]["message"]    = "%s sözünün tərcüməsi"
+    Locale["az"]["name"]               = "Azerbaijani"
+    Locale["az"]["endonym"]            = "Azərbaycanca"
+    Locale["az"]["translations-of"]    = "%s sözünün tərcüməsi"
+    Locale["az"]["definitions-of"]     = "%s sözünün tərifləri"
+    Locale["az"]["synonyms"]           = "Sinonimlər"
+    Locale["az"]["examples"]           = "Nümunələr"
+    Locale["az"]["see-also"]           = "Həmçinin, baxın:"
+    Locale["az"]["family"]             = "Turkic"
+    Locale["az"]["iso"]                = "aze"
+    Locale["az"]["glotto"]             = "azer1255"
+    Locale["az"]["script"]             = "Latn"
 
     #6 Basque
-    Locale["eu"]["name"]       = "Basque"
-    Locale["eu"]["endonym"]    = "Euskara"
-    Locale["eu"]["message"]    = "%s esapidearen itzulpena"
+    Locale["eu"]["name"]               = "Basque"
+    Locale["eu"]["endonym"]            = "Euskara"
+    Locale["eu"]["translations-of"]    = "%s esapidearen itzulpena"
+    Locale["eu"]["definitions-of"]     = "Honen definizioak: %s"
+    Locale["eu"]["synonyms"]           = "Sinonimoak"
+    Locale["eu"]["examples"]           = "Adibideak"
+    Locale["eu"]["see-also"]           = "Ikusi hauek ere"
+    #Locale["eu"]["family"]
+    Locale["eu"]["iso"]                = "eus"
+    Locale["eu"]["glotto"]             = "basq1248"
+    Locale["eu"]["script"]             = "Latn"
 
-    #7 Belarusian (Cyrillic alphabet)
-    Locale["be"]["name"]       = "Belarusian"
-    Locale["be"]["endonym"]    = "беларуская"
-    Locale["be"]["message"]    = "Пераклады %s"
+    #7 Belarusian, Cyrillic alphabet
+    Locale["be"]["name"]               = "Belarusian"
+    Locale["be"]["endonym"]            = "беларуская"
+    Locale["be"]["translations-of"]    = "Пераклады %s"
+    Locale["be"]["definitions-of"]     = "Вызначэннi %s"
+    Locale["be"]["synonyms"]           = "Сінонімы"
+    Locale["be"]["examples"]           = "Прыклады"
+    Locale["be"]["see-also"]           = "Гл. таксама"
+    Locale["be"]["family"]             = "Indo-European"
+    Locale["be"]["iso"]                = "bel"
+    Locale["be"]["glotto"]             = "bela1254"
+    Locale["be"]["script"]             = "Cyrl"
 
     #8 Bengali
-    Locale["bn"]["name"]       = "Bengali"
-    Locale["bn"]["endonym"]    = "বাংলা"
-    Locale["bn"]["message"]    = "%s এর অনুবাদ"
+    Locale["bn"]["name"]               = "Bengali"
+    Locale["bn"]["endonym"]            = "বাংলা"
+    Locale["bn"]["translations-of"]    = "%s এর অনুবাদ"
+    Locale["bn"]["definitions-of"]     = "%s এর সংজ্ঞা"
+    Locale["bn"]["synonyms"]           = "প্রতিশব্দ"
+    Locale["bn"]["examples"]           = "উদাহরণ"
+    Locale["bn"]["see-also"]           = "আরো দেখুন"
+    Locale["bn"]["family"]             = "Indo-European"
+    Locale["bn"]["iso"]                = "ben"
+    Locale["bn"]["glotto"]             = "beng1280"
+    Locale["bn"]["script"]             = "Beng"
 
-    #9 Bosnian (Latin alphabet)
-    Locale["bs"]["name"]       = "Bosnian"
-    Locale["bs"]["endonym"]    = "Bosanski"
-    Locale["bs"]["message"]    = "Prijevod za: %s"
+    #9 Bosnian, Latin alphabet
+    Locale["bs"]["name"]               = "Bosnian"
+    Locale["bs"]["endonym"]            = "Bosanski"
+    Locale["bs"]["translations-of"]    = "Prijevod za: %s"
+    Locale["bs"]["definitions-of"]     = "Definicije za %s"
+    Locale["bs"]["synonyms"]           = "Sinonimi"
+    Locale["bs"]["examples"]           = "Primjeri"
+    Locale["bs"]["see-also"]           = "Pogledajte i"
+    Locale["bs"]["family"]             = "Indo-European"
+    Locale["bs"]["iso"]                = "bos"
+    Locale["bs"]["glotto"]             = "bosn1245"
+    Locale["bs"]["script"]             = "Latn"
 
     #10 Bulgarian
-    Locale["bg"]["name"]       = "Bulgarian"
-    Locale["bg"]["endonym"]    = "български"
-    Locale["bg"]["message"]    = "Преводи на %s"
+    Locale["bg"]["name"]               = "Bulgarian"
+    Locale["bg"]["endonym"]            = "български"
+    Locale["bg"]["translations-of"]    = "Преводи на %s"
+    Locale["bg"]["definitions-of"]     = "Дефиниции за %s"
+    Locale["bg"]["synonyms"]           = "Синоними"
+    Locale["bg"]["examples"]           = "Примери"
+    Locale["bg"]["see-also"]           = "Вижте също"
+    Locale["bg"]["family"]             = "Indo-European"
+    Locale["bg"]["iso"]                = "bul"
+    Locale["bg"]["glotto"]             = "bulg1262"
+    Locale["bg"]["script"]             = "Cyrl"
 
     #11 Catalan
-    Locale["ca"]["name"]       = "Catalan"
-    Locale["ca"]["endonym"]    = "Català"
-    Locale["ca"]["message"]    = "Traduccions per a %s"
+    Locale["ca"]["name"]               = "Catalan"
+    Locale["ca"]["endonym"]            = "Català"
+    Locale["ca"]["translations-of"]    = "Traduccions per a %s"
+    Locale["ca"]["definitions-of"]     = "Definicions de: %s"
+    Locale["ca"]["synonyms"]           = "Sinònims"
+    Locale["ca"]["examples"]           = "Exemples"
+    Locale["ca"]["see-also"]           = "Vegeu també"
+    Locale["ca"]["family"]             = "Indo-European"
+    Locale["ca"]["iso"]                = "cat"
+    Locale["ca"]["glotto"]             = "stan1289"
+    Locale["ca"]["script"]             = "Latn"
 
     #12 Cebuano
-    Locale["ceb"]["name"]      = "Cebuano"
-    Locale["ceb"]["endonym"]   = "Cebuano"
-    Locale["ceb"]["message"]   = "%s Mga Paghubad sa PULONG_O_HUGPONG SA PAMULONG"
+    Locale["ceb"]["name"]              = "Cebuano"
+    Locale["ceb"]["endonym"]           = "Cebuano"
+    Locale["ceb"]["translations-of"]   = "%s Mga Paghubad sa PULONG_O_HUGPONG SA PAMULONG"
+    Locale["ceb"]["definitions-of"]    = "Mga kahulugan sa %s"
+    Locale["ceb"]["synonyms"]          = "Mga Kapulong"
+    Locale["ceb"]["examples"]          = "Mga pananglitan:"
+    Locale["ceb"]["see-also"]          = "Kitaa pag-usab"
+    Locale["ceb"]["family"]            = "Austronesian"
+    Locale["ceb"]["iso"]               = "ceb"
+    Locale["ceb"]["glotto"]            = "cebu1242"
+    Locale["ceb"]["script"]            = "Latn"
 
-    #13a Chinese (Simplified)
-    Locale["zh-CN"]["name"]    = "Chinese Simplified"
-    Locale["zh-CN"]["endonym"] = "简体中文"
-    Locale["zh-CN"]["message"] = "%s 的翻译"
+    #13 Chichewa
+    Locale["ny"]["name"]               = "Chichewa"
+    Locale["ny"]["endonym"]            = "Nyanja"
+    Locale["ny"]["translations-of"]    = "Matanthauzidwe a %s"
+    Locale["ny"]["definitions-of"]     = "Mamasulidwe a %s"
+    Locale["ny"]["synonyms"]           = "Mau ofanana"
+    Locale["ny"]["examples"]           = "Zitsanzo"
+    Locale["ny"]["see-also"]           = "Onaninso"
+    Locale["ny"]["family"]             = "Atlantic-Congo"
+    Locale["ny"]["iso"]                = "nya"
+    Locale["ny"]["glotto"]             = "nyan1308"
+    Locale["ny"]["script"]             = "Latn"
 
-    #13b Chinese (Traditional)
-    Locale["zh-TW"]["name"]    = "Chinese Traditional"
-    Locale["zh-TW"]["endonym"] = "正體中文"
-    Locale["zh-TW"]["message"] = "「%s」的翻譯"
+    #14a Chinese (Simplified)
+    Locale["zh-CN"]["name"]            = "Chinese Simplified"
+    Locale["zh-CN"]["endonym"]         = "简体中文"
+    Locale["zh-CN"]["translations-of"] = "%s 的翻译"
+    Locale["zh-CN"]["definitions-of"]  = "%s的定义"
+    Locale["zh-CN"]["synonyms"]        = "同义词"
+    Locale["zh-CN"]["examples"]        = "示例"
+    Locale["zh-CN"]["see-also"]        = "另请参阅"
+    Locale["zh-CN"]["family"]          = "Sino-Tibetan"
+    Locale["zh-CN"]["iso"]             = "zho"
+    Locale["zh-CN"]["glotto"]          = "mand1415"
+    Locale["zh-CN"]["script"]          = "Hans"
 
-    #14 Chichewa
-    Locale["ny"]["name"]       = "Chichewa"
-    Locale["ny"]["endonym"]    = "Nyanja"
-    Locale["ny"]["message"]    = "Matanthauzidwe a %s"
+    #14b Chinese (Traditional)
+    Locale["zh-TW"]["name"]            = "Chinese Traditional"
+    Locale["zh-TW"]["endonym"]         = "正體中文"
+    Locale["zh-TW"]["translations-of"] = "「%s」的翻譯"
+    Locale["zh-TW"]["definitions-of"]  = "「%s」的定義"
+    Locale["zh-TW"]["synonyms"]        = "同義詞"
+    Locale["zh-TW"]["examples"]        = "例句"
+    Locale["zh-TW"]["see-also"]        = "另請參閱"
+    Locale["zh-TW"]["family"]          = "Sino-Tibetan"
+    Locale["zh-TW"]["iso"]             = "zho"
+    Locale["zh-TW"]["glotto"]          = "mand1415"
+    Locale["zh-TW"]["script"]          = "Hant"
 
     #15 Croatian
-    Locale["hr"]["name"]       = "Croatian"
-    Locale["hr"]["endonym"]    = "Hrvatski"
-    Locale["hr"]["message"]    = "Prijevodi riječi ili izraza %s"
+    Locale["hr"]["name"]               = "Croatian"
+    Locale["hr"]["endonym"]            = "Hrvatski"
+    Locale["hr"]["translations-of"]    = "Prijevodi riječi ili izraza %s"
+    Locale["hr"]["definitions-of"]     = "Definicije riječi ili izraza %s"
+    Locale["hr"]["synonyms"]           = "Sinonimi"
+    Locale["hr"]["examples"]           = "Primjeri"
+    Locale["hr"]["see-also"]           = "Također pogledajte"
+    Locale["hr"]["family"]             = "Indo-European"
+    Locale["hr"]["iso"]                = "hrv"
+    Locale["hr"]["glotto"]             = "croa1245"
+    Locale["hr"]["script"]             = "Latn"
 
     #16 Czech
-    Locale["cs"]["name"]       = "Czech"
-    Locale["cs"]["endonym"]    = "Čeština"
-    Locale["cs"]["message"]    = "Překlad výrazu %s"
+    Locale["cs"]["name"]               = "Czech"
+    Locale["cs"]["endonym"]            = "Čeština"
+    Locale["cs"]["translations-of"]    = "Překlad výrazu %s"
+    Locale["cs"]["definitions-of"]     = "Definice výrazu %s"
+    Locale["cs"]["synonyms"]           = "Synonyma"
+    Locale["cs"]["examples"]           = "Příklady"
+    Locale["cs"]["see-also"]           = "Viz také"
+    Locale["cs"]["family"]             = "Indo-European"
+    Locale["cs"]["iso"]                = "ces"
+    Locale["cs"]["glotto"]             = "czec1258"
+    Locale["cs"]["script"]             = "Latn"
 
     #17 Danish
-    Locale["da"]["name"]       = "Danish"
-    Locale["da"]["endonym"]    = "Dansk"
-    Locale["da"]["message"]    = "Oversættelser af %s"
+    Locale["da"]["name"]               = "Danish"
+    Locale["da"]["endonym"]            = "Dansk"
+    Locale["da"]["translations-of"]    = "Oversættelser af %s"
+    Locale["da"]["definitions-of"]     = "Definitioner af %s"
+    Locale["da"]["synonyms"]           = "Synonymer"
+    Locale["da"]["examples"]           = "Eksempler"
+    Locale["da"]["see-also"]           = "Se også"
+    Locale["da"]["family"]             = "Indo-European"
+    Locale["da"]["iso"]                = "dan"
+    Locale["da"]["glotto"]             = "dani1285"
+    Locale["da"]["script"]             = "Latn"
 
     #18 Dutch
-    Locale["nl"]["name"]       = "Dutch"
-    Locale["nl"]["endonym"]    = "Nederlands"
-    Locale["nl"]["message"]    = "Vertalingen van %s"
+    Locale["nl"]["name"]               = "Dutch"
+    Locale["nl"]["endonym"]            = "Nederlands"
+    Locale["nl"]["translations-of"]    = "Vertalingen van %s"
+    Locale["nl"]["definitions-of"]     = "Definities van %s"
+    Locale["nl"]["synonyms"]           = "Synoniemen"
+    Locale["nl"]["examples"]           = "Voorbeelden"
+    Locale["nl"]["see-also"]           = "Zie ook"
+    Locale["nl"]["family"]             = "Indo-European"
+    Locale["nl"]["iso"]                = "nld"
+    Locale["nl"]["glotto"]             = "dutc1256"
+    Locale["nl"]["script"]             = "Latn"
 
     #19 English
-    Locale["en"]["name"]       = "English"
-    Locale["en"]["endonym"]    = "English"
-    Locale["en"]["message"]    = "Translations of %s"
+    Locale["en"]["name"]               = "English"
+    Locale["en"]["endonym"]            = "English"
+    Locale["en"]["translations-of"]    = "Translations of %s"
+    Locale["en"]["definitions-of"]     = "Definitions of %s"
+    Locale["en"]["synonyms"]           = "Synonyms"
+    Locale["en"]["examples"]           = "Examples"
+    Locale["en"]["see-also"]           = "See also"
+    Locale["en"]["family"]             = "Indo-European"
+    Locale["en"]["iso"]                = "eng"
+    Locale["en"]["glotto"]             = "stan1293"
+    Locale["en"]["script"]             = "Latn"
 
     #20 Esperanto
-    Locale["eo"]["name"]       = "Esperanto"
-    Locale["eo"]["endonym"]    = "Esperanto"
-    Locale["eo"]["message"]    = "Tradukoj de %s"
+    Locale["eo"]["name"]               = "Esperanto"
+    Locale["eo"]["endonym"]            = "Esperanto"
+    Locale["eo"]["translations-of"]    = "Tradukoj de %s"
+    Locale["eo"]["definitions-of"]     = "Difinoj de %s"
+    Locale["eo"]["synonyms"]           = "Sinonimoj"
+    Locale["eo"]["examples"]           = "Ekzemploj"
+    Locale["eo"]["see-also"]           = "Vidu ankaŭ"
+    Locale["eo"]["family"]             = "Artificial Language"
+    Locale["eo"]["iso"]                = "epo"
+    Locale["eo"]["glotto"]             = "espe1235"
+    Locale["eo"]["script"]             = "Latn"
 
     #21 Estonian
-    Locale["et"]["name"]       = "Estonian"
-    Locale["et"]["endonym"]    = "Eesti"
-    Locale["et"]["message"]    = "Sõna(de) %s tõlked"
+    Locale["et"]["name"]               = "Estonian"
+    Locale["et"]["endonym"]            = "Eesti"
+    Locale["et"]["translations-of"]    = "Sõna(de) %s tõlked"
+    Locale["et"]["definitions-of"]     = "Sõna(de) %s definitsioonid"
+    Locale["et"]["synonyms"]           = "Sünonüümid"
+    Locale["et"]["examples"]           = "Näited"
+    Locale["et"]["see-also"]           = "Vt ka"
+    Locale["et"]["family"]             = "Uralic"
+    Locale["et"]["iso"]                = "est"
+    Locale["et"]["glotto"]             = "esto1258"
+    Locale["et"]["script"]             = "Latn"
 
-    #22 Filipino
-    Locale["tl"]["name"]       = "Filipino"
-    Locale["tl"]["endonym"]    = "Tagalog"
-    Locale["tl"]["message"]    = "Mga pagsasalin ng %s"
+    #22 Filipino / Tagalog
+    Locale["tl"]["name"]               = "Filipino"
+    Locale["tl"]["endonym"]            = "Tagalog"
+    Locale["tl"]["translations-of"]    = "Mga pagsasalin ng %s"
+    Locale["tl"]["definitions-of"]     = "Mga kahulugan ng %s"
+    Locale["tl"]["synonyms"]           = "Mga Kasingkahulugan"
+    Locale["tl"]["examples"]           = "Mga Halimbawa"
+    Locale["tl"]["see-also"]           = "Tingnan rin ang"
+    Locale["tl"]["family"]             = "Austronesian"
+    Locale["tl"]["iso"]                = "tgl"
+    Locale["tl"]["glotto"]             = "taga1270"
+    Locale["tl"]["script"]             = "Latn"
 
     #23 Finnish
-    Locale["fi"]["name"]       = "Finnish"
-    Locale["fi"]["endonym"]    = "Suomi"
-    Locale["fi"]["message"]    = "Käännökset tekstille %s"
+    Locale["fi"]["name"]               = "Finnish"
+    Locale["fi"]["endonym"]            = "Suomi"
+    Locale["fi"]["translations-of"]    = "Käännökset tekstille %s"
+    Locale["fi"]["definitions-of"]     = "Määritelmät kohteelle %s"
+    Locale["fi"]["synonyms"]           = "Synonyymit"
+    Locale["fi"]["examples"]           = "Esimerkkejä"
+    Locale["fi"]["see-also"]           = "Katso myös"
+    Locale["fi"]["family"]             = "Uralic"
+    Locale["fi"]["iso"]                = "fin"
+    Locale["fi"]["glotto"]             = "finn1318"
+    Locale["fi"]["script"]             = "Latn"
 
     #24 French
-    Locale["fr"]["name"]       = "French"
-    Locale["fr"]["endonym"]    = "Français"
-    Locale["fr"]["message"]    = "Traductions de %s"
+    Locale["fr"]["name"]               = "French"
+    Locale["fr"]["endonym"]            = "Français"
+    Locale["fr"]["translations-of"]    = "Traductions de %s"
+    Locale["fr"]["definitions-of"]     = "Définitions de %s"
+    Locale["fr"]["synonyms"]           = "Synonymes"
+    Locale["fr"]["examples"]           = "Exemples"
+    Locale["fr"]["see-also"]           = "Voir aussi"
+    Locale["fr"]["family"]             = "Indo-European"
+    Locale["fr"]["iso"]                = "fra"
+    Locale["fr"]["glotto"]             = "stan1290"
+    Locale["fr"]["script"]             = "Latn"
 
     #25 Galician
-    Locale["gl"]["name"]       = "Galician"
-    Locale["gl"]["endonym"]    = "Galego"
-    Locale["gl"]["message"]    = "Traducións de %s"
+    Locale["gl"]["name"]               = "Galician"
+    Locale["gl"]["endonym"]            = "Galego"
+    Locale["gl"]["translations-of"]    = "Traducións de %s"
+    Locale["gl"]["definitions-of"]     = "Definicións de %s"
+    Locale["gl"]["synonyms"]           = "Sinónimos"
+    Locale["gl"]["examples"]           = "Exemplos"
+    Locale["gl"]["see-also"]           = "Ver tamén"
+    Locale["gl"]["family"]             = "Indo-European"
+    Locale["gl"]["iso"]                = "glg"
+    Locale["gl"]["glotto"]             = "gali1258"
+    Locale["gl"]["script"]             = "Latn"
 
-    #26 Georgian
-    Locale["ka"]["name"]       = "Georgian"
-    Locale["ka"]["endonym"]    = "ქართული"
-    Locale["ka"]["message"]    = "%s-ის თარგმანები"
+    #26 Georgian, Mkhedruli
+    Locale["ka"]["name"]               = "Georgian"
+    Locale["ka"]["endonym"]            = "ქართული"
+    Locale["ka"]["translations-of"]    = "%s-ის თარგმანები"
+    Locale["ka"]["definitions-of"]     = "%s-ის განსაზღვრებები"
+    Locale["ka"]["synonyms"]           = "სინონიმები"
+    Locale["ka"]["examples"]           = "მაგალითები"
+    Locale["ka"]["see-also"]           = "ასევე იხილეთ"
+    Locale["ka"]["family"]             = "Kartvelian"
+    Locale["ka"]["iso"]                = "kat"
+    Locale["ka"]["glotto"]             = "nucl1302"
+    Locale["ka"]["script"]             = "Geor"
 
     #27 German
-    Locale["de"]["name"]       = "German"
-    Locale["de"]["endonym"]    = "Deutsch"
-    Locale["de"]["message"]    = "Übersetzungen für %s"
+    Locale["de"]["name"]               = "German"
+    Locale["de"]["endonym"]            = "Deutsch"
+    Locale["de"]["translations-of"]    = "Übersetzungen für %s"
+    Locale["de"]["definitions-of"]     = "Definitionen von %s"
+    Locale["de"]["synonyms"]           = "Synonyme"
+    Locale["de"]["examples"]           = "Beispiele"
+    Locale["de"]["see-also"]           = "Siehe auch"
+    Locale["de"]["family"]             = "Indo-European"
+    Locale["de"]["iso"]                = "stan1295"
+    Locale["de"]["glotto"]             = "deu"
+    Locale["de"]["script"]             = "Latn"
 
-    #28 Greek
-    Locale["el"]["name"]       = "Greek"
-    Locale["el"]["endonym"]    = "Ελληνικά"
-    Locale["el"]["message"]    = "Μεταφράσεις του %s"
+    #28 Greek (Modern)
+    Locale["el"]["name"]               = "Greek"
+    Locale["el"]["endonym"]            = "Ελληνικά"
+    Locale["el"]["translations-of"]    = "Μεταφράσεις του %s"
+    Locale["el"]["definitions-of"]     = "Όρισμοί %s"
+    Locale["el"]["synonyms"]           = "Συνώνυμα"
+    Locale["el"]["examples"]           = "Παραδείγματα"
+    Locale["el"]["see-also"]           = "Δείτε επίσης"
+    Locale["el"]["family"]             = "Indo-European"
+    Locale["el"]["iso"]                = "ell"
+    Locale["el"]["glotto"]             = "mode1248"
+    Locale["el"]["script"]             = "Grek"
 
     #29 Gujarati
-    Locale["gu"]["name"]       = "Gujarati"
-    Locale["gu"]["endonym"]    = "ગુજરાતી"
-    Locale["gu"]["message"]    = "%s ના અનુવાદ"
+    Locale["gu"]["name"]               = "Gujarati"
+    Locale["gu"]["endonym"]            = "ગુજરાતી"
+    Locale["gu"]["translations-of"]    = "%s ના અનુવાદ"
+    Locale["gu"]["definitions-of"]     = "%s ની વ્યાખ્યાઓ"
+    Locale["gu"]["synonyms"]           = "સમાનાર્થી"
+    Locale["gu"]["examples"]           = "ઉદાહરણો"
+    Locale["gu"]["see-also"]           = "આ પણ જુઓ"
+    Locale["gu"]["family"]             = "Indo-European"
+    Locale["gu"]["iso"]                = "guj"
+    Locale["gu"]["glotto"]             = "guja1252"
+    Locale["gu"]["script"]             = "Gujr"
 
     #30 Haitian Creole
-    Locale["ht"]["name"]       = "Haitian Creole"
-    Locale["ht"]["endonym"]    = "Kreyòl Ayisyen"
-    Locale["ht"]["message"]    = "Tradiksyon %s"
+    Locale["ht"]["name"]               = "Haitian Creole"
+    Locale["ht"]["endonym"]            = "Kreyòl Ayisyen"
+    Locale["ht"]["translations-of"]    = "Tradiksyon %s"
+    Locale["ht"]["definitions-of"]     = "Definisyon nan %s"
+    Locale["ht"]["synonyms"]           = "Sinonim"
+    Locale["ht"]["examples"]           = "Egzanp:"
+    Locale["ht"]["see-also"]           = "Wè tou"
+    Locale["ht"]["family"]             = "Indo-European"
+    Locale["ht"]["iso"]                = "hat"
+    Locale["ht"]["glotto"]             = "hait1244"
+    Locale["ht"]["script"]             = "Latn"
 
-    #31 Hausa (Latin / Boko alphabet)
-    Locale["ha"]["name"]       = "Hausa"
-    Locale["ha"]["endonym"]    = "Hausa"
-    Locale["ha"]["message"]    = "Fassarar %s"
+    #31 Hausa, Latin / Boko alphabet
+    Locale["ha"]["name"]               = "Hausa"
+    Locale["ha"]["endonym"]            = "Hausa"
+    Locale["ha"]["translations-of"]    = "Fassarar %s"
+    Locale["ha"]["definitions-of"]     = "Ma'anoni na %s"
+    Locale["ha"]["synonyms"]           = "Masu kamancin ma'ana"
+    Locale["ha"]["examples"]           = "Misalai"
+    Locale["ha"]["see-also"]           = "Duba kuma"
+    Locale["ha"]["family"]             = "Afro-Asiatic"
+    Locale["ha"]["iso"]                = "hau"
+    Locale["ha"]["glotto"]             = "haus1257"
+    Locale["ha"]["script"]             = "Latn"
 
-    #32 Hebrew
-    Locale["he"]["name"]       = "Hebrew"
-    Locale["he"]["endonym"]    = "עִבְרִית"
-    Locale["he"]["message"]    = "תרגומים של %s"
-    Locale["he"]["rtl"]        = "true" # RTL language
+    #32 Hebrew (Modern)
+    Locale["he"]["name"]               = "Hebrew"
+    Locale["he"]["endonym"]            = "עִבְרִית"
+    Locale["he"]["translations-of"]    = "תרגומים של %s"
+    Locale["he"]["definitions-of"]     = "הגדרות של %s"
+    Locale["he"]["synonyms"]           = "מילים נרדפות"
+    Locale["he"]["examples"]           = "דוגמאות"
+    Locale["he"]["see-also"]           = "ראה גם"
+    Locale["he"]["family"]             = "Afro-Asiatic"
+    Locale["he"]["iso"]                = "heb"
+    Locale["he"]["glotto"]             = "hebr1245"
+    Locale["he"]["script"]             = "Hebr"
+    Locale["he"]["rtl"]                = "true" # RTL language
 
     #33 Hindi
-    Locale["hi"]["name"]       = "Hindi"
-    Locale["hi"]["endonym"]    = "हिन्दी"
-    Locale["hi"]["message"]    = "%s के अनुवाद"
+    Locale["hi"]["name"]               = "Hindi"
+    Locale["hi"]["endonym"]            = "हिन्दी"
+    Locale["hi"]["translations-of"]    = "%s के अनुवाद"
+    Locale["hi"]["definitions-of"]     = "%s की परिभाषाएं"
+    Locale["hi"]["synonyms"]           = "समानार्थी"
+    Locale["hi"]["examples"]           = "उदाहरण"
+    Locale["hi"]["see-also"]           = "यह भी देखें"
+    Locale["hi"]["family"]             = "Indo-European"
+    Locale["hi"]["iso"]                = "hin"
+    Locale["hi"]["glotto"]             = "hind1269"
+    Locale["hi"]["script"]             = "Deva"
 
     #34 Hmong
-    Locale["hmn"]["name"]      = "Hmong"
-    Locale["hmn"]["endonym"]   = "Hmoob"
-    Locale["hmn"]["message"]   = "Lus txhais: %s"
+    Locale["hmn"]["name"]              = "Hmong"
+    Locale["hmn"]["endonym"]           = "Hmoob"
+    Locale["hmn"]["translations-of"]   = "Lus txhais: %s"
+    #Locale["hmn"]["definitions-of"]
+    #Locale["hmn"]["synonyms"]
+    #Locale["hmn"]["examples"]
+    #Locale["hmn"]["see-also"]
+    Locale["hmn"]["family"]            = "Hmong-Mien"
+    Locale["hmn"]["iso"]               = "hmn"
+    Locale["hmn"]["glotto"]            = "firs1234"
+    Locale["hmn"]["script"]            = "Latn"
 
     #35 Hungarian
-    Locale["hu"]["name"]       = "Hungarian"
-    Locale["hu"]["endonym"]    = "Magyar"
-    Locale["hu"]["message"]    = "%s fordításai"
+    Locale["hu"]["name"]               = "Hungarian"
+    Locale["hu"]["endonym"]            = "Magyar"
+    Locale["hu"]["translations-of"]    = "%s fordításai"
+    Locale["hu"]["definitions-of"]     = "%s jelentései"
+    Locale["hu"]["synonyms"]           = "Szinonimák"
+    Locale["hu"]["examples"]           = "Példák"
+    Locale["hu"]["see-also"]           = "Lásd még"
+    Locale["hu"]["family"]             = "Uralic"
+    Locale["hu"]["iso"]                = "hun"
+    Locale["hu"]["glotto"]             = "hung1274"
+    Locale["hu"]["script"]             = "Latn"
 
     #36 Icelandic
-    Locale["is"]["name"]       = "Icelandic"
-    Locale["is"]["endonym"]    = "Íslenska"
-    Locale["is"]["message"]    = "Þýðingar á %s"
+    Locale["is"]["name"]               = "Icelandic"
+    Locale["is"]["endonym"]            = "Íslenska"
+    Locale["is"]["translations-of"]    = "Þýðingar á %s"
+    Locale["is"]["definitions-of"]     = "Skilgreiningar á"
+    Locale["is"]["synonyms"]           = "Samheiti"
+    Locale["is"]["examples"]           = "Dæmi"
+    Locale["is"]["see-also"]           = "Sjá einnig"
+    Locale["is"]["family"]             = "Indo-European"
+    Locale["is"]["iso"]                = "isl"
+    Locale["is"]["glotto"]             = "icel1247"
+    Locale["is"]["script"]             = "Latn"
 
     #37 Igbo
-    Locale["ig"]["name"]       = "Igbo"
-    Locale["ig"]["endonym"]    = "Igbo"
-    Locale["ig"]["message"]    = "Ntụgharị asụsụ nke %s"
+    Locale["ig"]["name"]               = "Igbo"
+    Locale["ig"]["endonym"]            = "Igbo"
+    Locale["ig"]["translations-of"]    = "Ntụgharị asụsụ nke %s"
+    Locale["ig"]["definitions-of"]     = "Nkọwapụta nke %s"
+    Locale["ig"]["synonyms"]           = "Okwu oyiri"
+    Locale["ig"]["examples"]           = "Ọmụmaatụ"
+    Locale["ig"]["see-also"]           = "Hụkwuo"
+    Locale["ig"]["family"]             = "Atlantic-Congo"
+    Locale["ig"]["iso"]                = "ibo"
+    Locale["ig"]["glotto"]             = "igbo1259"
+    Locale["ig"]["script"]             = "Latn"
 
     #38 Indonesian
-    Locale["id"]["name"]       = "Indonesian"
-    Locale["id"]["endonym"]    = "Bahasa Indonesia"
-    Locale["id"]["message"]    = "Terjemahan dari %s"
+    Locale["id"]["name"]               = "Indonesian"
+    Locale["id"]["endonym"]            = "Bahasa Indonesia"
+    Locale["id"]["translations-of"]    = "Terjemahan dari %s"
+    Locale["id"]["definitions-of"]     = "Definisi %s"
+    Locale["id"]["synonyms"]           = "Sinonim"
+    Locale["id"]["examples"]           = "Contoh"
+    Locale["id"]["see-also"]           = "Lihat juga"
+    Locale["id"]["family"]             = "Austronesian"
+    Locale["id"]["iso"]                = "ind"
+    Locale["id"]["glotto"]             = "indo1316"
+    Locale["id"]["script"]             = "Latn"
 
     #39 Irish
-    Locale["ga"]["name"]       = "Irish"
-    Locale["ga"]["endonym"]    = "Gaeilge"
-    Locale["ga"]["message"]    = "Aistriúcháin ar %s"
+    Locale["ga"]["name"]               = "Irish"
+    Locale["ga"]["endonym"]            = "Gaeilge"
+    Locale["ga"]["translations-of"]    = "Aistriúcháin ar %s"
+    Locale["ga"]["definitions-of"]     = "Sainmhínithe ar %s"
+    Locale["ga"]["synonyms"]           = "Comhchiallaigh"
+    Locale["ga"]["examples"]           = "Samplaí"
+    Locale["ga"]["see-also"]           = "féach freisin"
+    Locale["ga"]["family"]             = "Indo-European"
+    Locale["ga"]["iso"]                = "gle"
+    Locale["ga"]["glotto"]             = "iris1253"
+    Locale["ga"]["script"]             = "Latn"
 
     #40 Italian
-    Locale["it"]["name"]       = "Italian"
-    Locale["it"]["endonym"]    = "Italiano"
-    Locale["it"]["message"]    = "Traduzioni di %s"
+    Locale["it"]["name"]               = "Italian"
+    Locale["it"]["endonym"]            = "Italiano"
+    Locale["it"]["translations-of"]    = "Traduzioni di %s"
+    Locale["it"]["definitions-of"]     = "Definizioni di %s"
+    Locale["it"]["synonyms"]           = "Sinonimi"
+    Locale["it"]["examples"]           = "Esempi"
+    Locale["it"]["see-also"]           = "Vedi anche"
+    Locale["it"]["family"]             = "Indo-European"
+    Locale["it"]["iso"]                = "ita"
+    Locale["it"]["glotto"]             = "ital1282"
+    Locale["it"]["script"]             = "Latn"
 
     #41 Japanese
-    Locale["ja"]["name"]       = "Japanese"
-    Locale["ja"]["endonym"]    = "日本語"
-    Locale["ja"]["message"]    = "「%s」の翻訳"
+    Locale["ja"]["name"]               = "Japanese"
+    Locale["ja"]["endonym"]            = "日本語"
+    Locale["ja"]["translations-of"]    = "「%s」の翻訳"
+    Locale["ja"]["definitions-of"]     = "%s の定義"
+    Locale["ja"]["synonyms"]           = "同義語"
+    Locale["ja"]["examples"]           = "例"
+    Locale["ja"]["see-also"]           = "関連項目"
+    Locale["ja"]["family"]             = "Japonic"
+    Locale["ja"]["iso"]                = "jpn"
+    Locale["ja"]["glotto"]             = "japa1256"
+    Locale["ja"]["script"]             = "Jpan"
 
-    #42 Javanese (Latin alphabet)
-    Locale["jv"]["name"]       = "Javanese"
-    Locale["jv"]["endonym"]    = "Basa Jawa"
-    Locale["jv"]["message"]    = "Terjemahan"
+    #42 Javanese, Latin alphabet
+    Locale["jv"]["name"]               = "Javanese"
+    Locale["jv"]["endonym"]            = "Basa Jawa"
+    Locale["jv"]["translations-of"]    = "Terjemahan %s"
+    Locale["jv"]["definitions-of"]     = "Arti %s"
+    Locale["jv"]["synonyms"]           = "Sinonim"
+    Locale["jv"]["examples"]           = "Conto"
+    Locale["jv"]["see-also"]           = "Deleng uga"
+    Locale["jv"]["family"]             = "Austronesian"
+    Locale["jv"]["iso"]                = "jav"
+    Locale["jv"]["glotto"]             = "java1254"
+    Locale["jv"]["script"]             = "Latn"
 
     #43 Kannada
-    Locale["kn"]["name"]       = "Kannada"
-    Locale["kn"]["endonym"]    = "ಕನ್ನಡ"
-    Locale["kn"]["message"]    = "%s ನ ಅನುವಾದಗಳು"
+    Locale["kn"]["name"]               = "Kannada"
+    Locale["kn"]["endonym"]            = "ಕನ್ನಡ"
+    Locale["kn"]["translations-of"]    = "%s ನ ಅನುವಾದಗಳು"
+    Locale["kn"]["definitions-of"]     = "%s ನ ವ್ಯಾಖ್ಯಾನಗಳು"
+    Locale["kn"]["synonyms"]           = "ಸಮಾನಾರ್ಥಕಗಳು"
+    Locale["kn"]["examples"]           = "ಉದಾಹರಣೆಗಳು"
+    Locale["kn"]["see-also"]           = "ಇದನ್ನೂ ಗಮನಿಸಿ"
+    Locale["kn"]["family"]             = "Dravidian"
+    Locale["kn"]["iso"]                = "kan"
+    Locale["kn"]["glotto"]             = "kann1255"
+    Locale["kn"]["script"]             = "Knda"
 
-    #44 Kazakh (Cyrillic alphabet)
-    Locale["kk"]["name"]       = "Kazakh"
-    Locale["kk"]["endonym"]    = "Қазақ тілі"
-    Locale["kk"]["message"]    = "%s аудармалары"
+    #44 Kazakh, Cyrillic alphabet
+    Locale["kk"]["name"]               = "Kazakh"
+    Locale["kk"]["endonym"]            = "Қазақ тілі"
+    Locale["kk"]["translations-of"]    = "%s аудармалары"
+    Locale["kk"]["definitions-of"]     = "%s анықтамалары"
+    Locale["kk"]["synonyms"]           = "Синонимдер"
+    Locale["kk"]["examples"]           = "Мысалдар"
+    Locale["kk"]["see-also"]           = "Келесі тізімді де көріңіз:"
+    Locale["kk"]["family"]             = "Turkic"
+    Locale["kk"]["iso"]                = "kaz"
+    Locale["kk"]["glotto"]             = "kaza1248"
+    Locale["kk"]["script"]             = "Cyrl"
 
     #45 Khmer (Central Khmer)
-    Locale["km"]["name"]       = "Khmer"
-    Locale["km"]["endonym"]    = "ភាសាខ្មែរ"
-    Locale["km"]["message"]    = "ការ​បក​ប្រែ​នៃ %s"
+    Locale["km"]["name"]               = "Khmer"
+    Locale["km"]["endonym"]            = "ភាសាខ្មែរ"
+    Locale["km"]["translations-of"]    = "ការ​បក​ប្រែ​នៃ %s"
+    Locale["km"]["definitions-of"]     = "និយមន័យ​នៃ​ %s"
+    Locale["km"]["synonyms"]           = "សទិសន័យ"
+    Locale["km"]["examples"]           = "ឧទាហរណ៍"
+    Locale["km"]["see-also"]           = "មើល​ផង​ដែរ"
+    Locale["km"]["family"]             = "Austroasiatic"
+    Locale["km"]["iso"]                = "khm"
+    Locale["km"]["glotto"]             = "cent1989"
+    Locale["km"]["script"]             = "Khmr"
 
     #46 Korean
-    Locale["ko"]["name"]       = "Korean"
-    Locale["ko"]["endonym"]    = "한국어"
-    Locale["ko"]["message"]    = "%s의 번역"
+    Locale["ko"]["name"]               = "Korean"
+    Locale["ko"]["endonym"]            = "한국어"
+    Locale["ko"]["translations-of"]    = "%s의 번역"
+    Locale["ko"]["definitions-of"]     = "%s의 정의"
+    Locale["ko"]["synonyms"]           = "동의어"
+    Locale["ko"]["examples"]           = "예문"
+    Locale["ko"]["see-also"]           = "참조"
+    Locale["ko"]["family"]             = "Koreanic"
+    Locale["ko"]["iso"]                = "kor"
+    Locale["ko"]["glotto"]             = "kore1280"
+    Locale["ko"]["script"]             = "Kore"
 
     #47 Lao
-    Locale["lo"]["name"]       = "Lao"
-    Locale["lo"]["endonym"]    = "ລາວ"
-    Locale["lo"]["message"]    = "ການ​ແປ​ພາ​ສາ​ຂອງ %s"
+    Locale["lo"]["name"]               = "Lao"
+    Locale["lo"]["endonym"]            = "ລາວ"
+    Locale["lo"]["translations-of"]    = "ຄຳ​ແປ​ສຳລັບ %s"
+    Locale["lo"]["definitions-of"]     = "ຄວາມໝາຍຂອງ %s"
+    Locale["lo"]["synonyms"]           = "ຄຳທີ່ຄ້າຍກັນ %s"
+    Locale["lo"]["examples"]           = "ຕົວຢ່າງ"
+    Locale["lo"]["see-also"]           = "ເບິ່ງ​ເພີ່ມ​ເຕີມ"
+    Locale["lo"]["family"]             = "Tai-Kadai"
+    Locale["lo"]["iso"]                = "lao"
+    Locale["lo"]["glotto"]             = "laoo1244"
+    Locale["lo"]["script"]             = "Laoo"
 
     #48 Latin
-    Locale["la"]["name"]       = "Latin"
-    Locale["la"]["endonym"]    = "Latina"
-    Locale["la"]["message"]    = "Versio de %s"
+    Locale["la"]["name"]               = "Latin"
+    Locale["la"]["endonym"]            = "Latina"
+    Locale["la"]["translations-of"]    = "Versio de %s"
+    #Locale["la"]["definitions-of"]     = ""
+    #Locale["la"]["synonyms"]           = ""
+    #Locale["la"]["examples"]           = ""
+    #Locale["la"]["see-also"]           = ""
+    Locale["la"]["family"]             = "Indo-European"
+    Locale["la"]["iso"]                = "lat"
+    Locale["la"]["glotto"]             = "lati1261"
+    Locale["la"]["script"]             = "Latn"
 
     #49 Latvian
-    Locale["lv"]["name"]       = "Latvian"
-    Locale["lv"]["endonym"]    = "Latviešu"
-    Locale["lv"]["message"]    = "%s tulkojumi"
+    Locale["lv"]["name"]               = "Latvian"
+    Locale["lv"]["endonym"]            = "Latviešu"
+    Locale["lv"]["translations-of"]    = "%s tulkojumi"
+    Locale["lv"]["definitions-of"]     = "%s definīcijas"
+    Locale["lv"]["synonyms"]           = "Sinonīmi"
+    Locale["lv"]["examples"]           = "Piemēri"
+    Locale["lv"]["see-also"]           = "Skatiet arī"
+    Locale["lv"]["family"]             = "Indo-European"
+    Locale["lv"]["iso"]                = "lav"
+    Locale["lv"]["glotto"]             = "latv1249"
+    Locale["lv"]["script"]             = "Latn"
 
     #50 Lithuanian
-    Locale["lt"]["name"]       = "Lithuanian"
-    Locale["lt"]["endonym"]    = "Lietuvių"
-    Locale["lt"]["message"]    = "„%s“ vertimai"
+    Locale["lt"]["name"]               = "Lithuanian"
+    Locale["lt"]["endonym"]            = "Lietuvių"
+    Locale["lt"]["translations-of"]    = "„%s“ vertimai"
+    Locale["lt"]["definitions-of"]     = "„%s“ apibrėžimai"
+    Locale["lt"]["synonyms"]           = "Sinonimai"
+    Locale["lt"]["examples"]           = "Pavyzdžiai"
+    Locale["lt"]["see-also"]           = "Taip pat žiūrėkite"
+    Locale["lt"]["family"]             = "Indo-European"
+    Locale["lt"]["iso"]                = "lit"
+    Locale["lt"]["glotto"]             = "lith1251"
+    Locale["lt"]["script"]             = "Latn"
 
     #51 Macedonian
-    Locale["mk"]["name"]       = "Macedonian"
-    Locale["mk"]["endonym"]    = "Македонски"
-    Locale["mk"]["message"]    = "Преводи на %s"
+    Locale["mk"]["name"]               = "Macedonian"
+    Locale["mk"]["endonym"]            = "Македонски"
+    Locale["mk"]["translations-of"]    = "Преводи на %s"
+    Locale["mk"]["definitions-of"]     = "Дефиниции на %s"
+    Locale["mk"]["synonyms"]           = "Синоними"
+    Locale["mk"]["examples"]           = "Примери"
+    Locale["mk"]["see-also"]           = "Види и"
+    Locale["mk"]["family"]             = "Indo-European"
+    Locale["mk"]["iso"]                = "mkd"
+    Locale["mk"]["glotto"]             = "mace1250"
+    Locale["mk"]["script"]             = "Cyrl"
 
-    #52 Malagasy
-    Locale["mg"]["name"]       = "Malagasy"
-    Locale["mg"]["endonym"]    = "Malagasy"
-    Locale["mg"]["message"]    = "Dikan'ny %s"
+    #52 Malagasy (Merina dialect, Plateau Malagasy)
+    Locale["mg"]["name"]               = "Malagasy"
+    Locale["mg"]["endonym"]            = "Malagasy"
+    Locale["mg"]["translations-of"]    = "Dikan'ny %s"
+    Locale["mg"]["definitions-of"]     = "Famaritana ny %s"
+    Locale["mg"]["synonyms"]           = "Mitovy hevitra"
+    Locale["mg"]["examples"]           = "Ohatra"
+    Locale["mg"]["see-also"]           = "Jereo ihany koa"
+    Locale["mg"]["family"]             = "Austronesian"
+    Locale["mg"]["iso"]                = "mlg"
+    Locale["mg"]["glotto"]             = "plat1254"
+    Locale["mg"]["script"]             = "Latn"
 
     #53 Malay
-    Locale["ms"]["name"]       = "Malay"
-    Locale["ms"]["endonym"]    = "Bahasa Melayu"
-    Locale["ms"]["message"]    = "Terjemahan %s"
+    Locale["ms"]["name"]               = "Malay"
+    Locale["ms"]["endonym"]            = "Bahasa Melayu"
+    Locale["ms"]["translations-of"]    = "Terjemahan %s"
+    Locale["ms"]["definitions-of"]     = "Takrif %s"
+    Locale["ms"]["synonyms"]           = "Sinonim"
+    Locale["ms"]["examples"]           = "Contoh"
+    Locale["ms"]["see-also"]           = "Lihat juga"
+    Locale["ms"]["family"]             = "Austronesian"
+    Locale["ms"]["iso"]                = "msa"
+    Locale["ms"]["glotto"]             = "stan1306"
+    Locale["ms"]["script"]             = "Latn"
 
     #54 Malayalam
-    Locale["ml"]["name"]       = "Malayalam"
-    Locale["ml"]["endonym"]    = "മലയാളം"
-    Locale["ml"]["message"]    = "%s എന്നതിന്റെ വിവർത്തനങ്ങൾ"
+    Locale["ml"]["name"]               = "Malayalam"
+    Locale["ml"]["endonym"]            = "മലയാളം"
+    Locale["ml"]["translations-of"]    = "%s എന്നതിന്റെ വിവർത്തനങ്ങൾ"
+    Locale["ml"]["definitions-of"]     = "%s എന്നതിന്റെ നിർവ്വചനങ്ങൾ"
+    Locale["ml"]["synonyms"]           = "പര്യായങ്ങള്‍"
+    Locale["ml"]["examples"]           = "ഉദാഹരണങ്ങള്‍"
+    Locale["ml"]["see-also"]           = "ഇതും കാണുക"
+    Locale["ml"]["family"]             = "Dravidian"
+    Locale["ml"]["iso"]                = "mal"
+    Locale["ml"]["glotto"]             = "mala1464"
+    Locale["ml"]["script"]             = "Mlym"
 
     #55 Maltese
-    Locale["mt"]["name"]       = "Maltese"
-    Locale["mt"]["endonym"]    = "Malti"
-    Locale["mt"]["message"]    = "Traduzzjonijiet ta' %s"
+    Locale["mt"]["name"]               = "Maltese"
+    Locale["mt"]["endonym"]            = "Malti"
+    Locale["mt"]["translations-of"]    = "Traduzzjonijiet ta' %s"
+    Locale["mt"]["definitions-of"]     = "Definizzjonijiet ta' %s"
+    Locale["mt"]["synonyms"]           = "Sinonimi"
+    Locale["mt"]["examples"]           = "Eżempji"
+    Locale["mt"]["see-also"]           = "Ara wkoll"
+    Locale["mt"]["family"]             = "Afro-Asiatic"
+    Locale["mt"]["iso"]                = "mlt"
+    Locale["mt"]["glotto"]             = "malt1254"
+    Locale["mt"]["script"]             = "Latn"
 
     #56 Maori
-    Locale["mi"]["name"]       = "Maori"
-    Locale["mi"]["endonym"]    = "Māori"
-    Locale["mi"]["message"]    = "Ngā whakamāoritanga o %s"
+    Locale["mi"]["name"]               = "Maori"
+    Locale["mi"]["endonym"]            = "Māori"
+    Locale["mi"]["translations-of"]    = "Ngā whakamāoritanga o %s"
+    Locale["mi"]["definitions-of"]     = "Ngā whakamārama o %s"
+    Locale["mi"]["synonyms"]           = "Ngā Kupu Taurite"
+    Locale["mi"]["examples"]           = "Ngā Tauira:"
+    Locale["mi"]["see-also"]           = "Tiro hoki:"
+    Locale["mi"]["family"]             = "Austronesian"
+    Locale["mi"]["iso"]                = "mri"
+    Locale["mi"]["glotto"]             = "maor1246"
+    Locale["mi"]["script"]             = "Latn"
 
     #57 Marathi
-    Locale["mr"]["name"]       = "Marathi"
-    Locale["mr"]["endonym"]    = "मराठी"
-    Locale["mr"]["message"]    = "%s ची भाषांतरे"
+    Locale["mr"]["name"]               = "Marathi"
+    Locale["mr"]["endonym"]            = "मराठी"
+    Locale["mr"]["translations-of"]    = "%s ची भाषांतरे"
+    Locale["mr"]["definitions-of"]     = "%s च्या व्याख्या"
+    Locale["mr"]["synonyms"]           = "समानार्थी शब्द"
+    Locale["mr"]["examples"]           = "उदाहरणे"
+    Locale["mr"]["see-also"]           = "हे देखील पहा"
+    Locale["mr"]["family"]             = "Indo-European"
+    Locale["mr"]["iso"]                = "mar"
+    Locale["mr"]["glotto"]             = "mara1378"
+    Locale["mr"]["script"]             = "Deva"
 
-    #58 Mongolian (Cyrillic alphabet)
-    Locale["mn"]["name"]       = "Mongolian"
-    Locale["mn"]["endonym"]    = "Монгол"
-    Locale["mn"]["message"]    = "%s-н орчуулга"
+    #58 Mongolian, Cyrillic alphabet
+    Locale["mn"]["name"]               = "Mongolian"
+    Locale["mn"]["endonym"]            = "Монгол"
+    Locale["mn"]["translations-of"]    = "%s-н орчуулга"
+    Locale["mn"]["definitions-of"]     = "%s үгийн тодорхойлолт"
+    Locale["mn"]["synonyms"]           = "Ойролцоо утгатай"
+    Locale["mn"]["examples"]           = "Жишээнүүд"
+    Locale["mn"]["see-also"]           = "Мөн харах"
+    Locale["mn"]["family"]             = "Mongolic"
+    Locale["mn"]["iso"]                = "mon"
+    Locale["mn"]["glotto"]             = "mong1331"
+    Locale["mn"]["script"]             = "Cyrl"
 
-    #59 Myanmar (Burmese)
-    Locale["my"]["name"]       = "Myanmar"
-    Locale["my"]["endonym"]    = "မြန်မာစာ"
-    Locale["my"]["message"]    = "%s၏ ဘာသာပြန်ဆိုချက်များ"
+    #59 Myanmar / Burmese
+    Locale["my"]["name"]               = "Myanmar"
+    Locale["my"]["endonym"]            = "မြန်မာစာ"
+    Locale["my"]["translations-of"]    = "%s၏ ဘာသာပြန်ဆိုချက်များ"
+    Locale["my"]["definitions-of"]     = "%s၏ အနက်ဖွင့်ဆိုချက်များ"
+    Locale["my"]["synonyms"]           = "ကြောင်းတူသံကွဲများ"
+    Locale["my"]["examples"]           = "ဥပမာ"
+    Locale["my"]["see-also"]           = "ဖော်ပြပါများကိုလဲ ကြည့်ပါ"
+    Locale["my"]["family"]             = "Sino-Tibetan"
+    Locale["my"]["iso"]                = "mya"
+    Locale["my"]["glotto"]             = "nucl1310"
+    Locale["my"]["script"]             = "Mymr"
 
     #60 Nepali
-    Locale["ne"]["name"]       = "Nepali"
-    Locale["ne"]["endonym"]    = "नेपाली"
-    Locale["ne"]["message"]    = "%sका अनुवाद"
+    Locale["ne"]["name"]               = "Nepali"
+    Locale["ne"]["endonym"]            = "नेपाली"
+    Locale["ne"]["translations-of"]    = "%sका अनुवाद"
+    Locale["ne"]["definitions-of"]     = "%sको परिभाषा"
+    Locale["ne"]["synonyms"]           = "समानार्थीहरू"
+    Locale["ne"]["examples"]           = "उदाहरणहरु"
+    Locale["ne"]["see-also"]           = "यो पनि हेर्नुहोस्"
+    Locale["ne"]["family"]             = "Indo-European"
+    Locale["ne"]["iso"]                = "nep"
+    Locale["ne"]["glotto"]             = "nepa1254"
+    Locale["ne"]["script"]             = "Deva"
 
     #61 Norwegian
-    Locale["no"]["name"]       = "Norwegian"
-    Locale["no"]["endonym"]    = "Norsk"
-    Locale["no"]["message"]    = "Oversettelser av %s"
+    Locale["no"]["name"]               = "Norwegian"
+    Locale["no"]["endonym"]            = "Norsk"
+    Locale["no"]["translations-of"]    = "Oversettelser av %s"
+    Locale["no"]["definitions-of"]     = "Definisjoner av %s"
+    Locale["no"]["synonyms"]           = "Synonymer"
+    Locale["no"]["examples"]           = "Eksempler"
+    Locale["no"]["see-also"]           = "Se også"
+    Locale["no"]["family"]             = "Indo-European"
+    Locale["no"]["iso"]                = "nor"
+    Locale["no"]["glotto"]             = "norw1258"
+    Locale["no"]["script"]             = "Latn"
 
-    #62 Persian
-    Locale["fa"]["name"]       = "Persian"
-    Locale["fa"]["endonym"]    = "فارسی"
-    Locale["fa"]["message"]    = "ترجمه‌های %s"
-    Locale["fa"]["rtl"]        = "true" # RTL language
+    #62 Persian (Farsi)
+    Locale["fa"]["name"]               = "Persian"
+    Locale["fa"]["endonym"]            = "فارسی"
+    Locale["fa"]["translations-of"]    = "ترجمه‌های %s"
+    Locale["fa"]["definitions-of"]     = "تعریف‌های %s"
+    Locale["fa"]["synonyms"]           = "مترادف‌ها"
+    Locale["fa"]["examples"]           = "مثال‌ها"
+    Locale["fa"]["see-also"]           = "همچنین مراجعه کنید به"
+    Locale["fa"]["family"]             = "Indo-European"
+    Locale["fa"]["iso"]                = "fas"
+    #Locale["fa"]["glotto"]
+    Locale["fa"]["script"]             = "Arab"
+    Locale["fa"]["rtl"]                = "true" # RTL language
 
-    #63 Punjabi (Brahmic / Gurmukhī alphabet)
-    Locale["pa"]["name"]       = "Punjabi"
-    Locale["pa"]["endonym"]    = "ਪੰਜਾਬੀ"
-    Locale["pa"]["message"]    = "ਦੇ ਅਨੁਵਾਦ%s"
+    #63 Punjabi, Brahmic / Gurmukhī alphabet
+    Locale["pa"]["name"]               = "Punjabi"
+    Locale["pa"]["endonym"]            = "ਪੰਜਾਬੀ"
+    Locale["pa"]["translations-of"]    = "ਦੇ ਅਨੁਵਾਦ%s"
+    Locale["pa"]["definitions-of"]     = "ਦੀਆਂ ਪਰਿਭਾਸ਼ਾ %s"
+    Locale["pa"]["synonyms"]           = "ਸਮਾਨਾਰਥਕ ਸ਼ਬਦ"
+    Locale["pa"]["examples"]           = "ਉਦਾਹਰਣਾਂ"
+    Locale["pa"]["see-also"]           = "ਇਹ ਵੀ ਵੇਖੋ"
+    Locale["pa"]["family"]             = "Indo-European"
+    Locale["pa"]["iso"]                = "pan"
+    Locale["pa"]["glotto"]             = "panj1256"
+    Locale["pa"]["script"]             = "Guru"
 
     #64 Polish
-    Locale["pl"]["name"]       = "Polish"
-    Locale["pl"]["endonym"]    = "Polski"
-    Locale["pl"]["message"]    = "Tłumaczenia %s"
+    Locale["pl"]["name"]               = "Polish"
+    Locale["pl"]["endonym"]            = "Polski"
+    Locale["pl"]["translations-of"]    = "Tłumaczenia %s"
+    Locale["pl"]["definitions-of"]     = "%s – definicje"
+    Locale["pl"]["synonyms"]           = "Synonimy"
+    Locale["pl"]["examples"]           = "Przykłady"
+    Locale["pl"]["see-also"]           = "Zobacz też"
+    Locale["pl"]["family"]             = "Indo-European"
+    Locale["pl"]["iso"]                = "pol"
+    Locale["pl"]["glotto"]             = "poli1260"
+    Locale["pl"]["script"]             = "Latn"
 
     #65 Portuguese
-    Locale["pt"]["name"]       = "Portuguese"
-    Locale["pt"]["endonym"]    = "Português"
-    Locale["pt"]["message"]    = "Traduções de %s"
+    Locale["pt"]["name"]               = "Portuguese"
+    Locale["pt"]["endonym"]            = "Português"
+    Locale["pt"]["translations-of"]    = "Traduções de %s"
+    Locale["pt"]["definitions-of"]     = "Definições de %s"
+    Locale["pt"]["synonyms"]           = "Sinônimos"
+    Locale["pt"]["examples"]           = "Exemplos"
+    Locale["pt"]["see-also"]           = "Veja também"
+    Locale["pt"]["family"]             = "Indo-European"
+    Locale["pt"]["iso"]                = "por"
+    Locale["pt"]["glotto"]             = "port1283"
+    Locale["pt"]["script"]             = "Latn"
 
     #66 Romanian
-    Locale["ro"]["name"]       = "Romanian"
-    Locale["ro"]["endonym"]    = "Română"
-    Locale["ro"]["message"]    = "Traduceri pentru %s"
+    Locale["ro"]["name"]               = "Romanian"
+    Locale["ro"]["endonym"]            = "Română"
+    Locale["ro"]["translations-of"]    = "Traduceri pentru %s"
+    Locale["ro"]["definitions-of"]     = "Definiții pentru %s"
+    Locale["ro"]["synonyms"]           = "Sinonime"
+    Locale["ro"]["examples"]           = "Exemple"
+    Locale["ro"]["see-also"]           = "Vedeți și"
+    Locale["ro"]["family"]             = "Indo-European"
+    Locale["ro"]["iso"]                = "ron"
+    Locale["ro"]["glotto"]             = "roma1327"
+    Locale["ro"]["script"]             = "Latn"
 
     #67 Russian
-    Locale["ru"]["name"]       = "Russian"
-    Locale["ru"]["endonym"]    = "Русский"
-    Locale["ru"]["message"]    = "%s: варианты перевода"
+    Locale["ru"]["name"]               = "Russian"
+    Locale["ru"]["endonym"]            = "Русский"
+    Locale["ru"]["translations-of"]    = "%s: варианты перевода"
+    Locale["ru"]["definitions-of"]     = "%s – определения"
+    Locale["ru"]["synonyms"]           = "Синонимы"
+    Locale["ru"]["examples"]           = "Примеры"
+    Locale["ru"]["see-also"]           = "Похожие слова"
+    Locale["ru"]["family"]             = "Indo-European"
+    Locale["ru"]["iso"]                = "rus"
+    Locale["ru"]["glotto"]             = "russ1263"
+    Locale["ru"]["script"]             = "Cyrl"
 
-    #68 Serbian (Cyrillic alphabet)
-    Locale["sr"]["name"]       = "Serbian"
-    Locale["sr"]["endonym"]    = "српски"
-    Locale["sr"]["message"]    = "Преводи за „%s“"
+    #68 Serbian, Cyrillic alphabet
+    Locale["sr"]["name"]               = "Serbian"
+    Locale["sr"]["endonym"]            = "српски"
+    Locale["sr"]["translations-of"]    = "Преводи за „%s“"
+    Locale["sr"]["definitions-of"]     = "Дефиниције за %s"
+    Locale["sr"]["synonyms"]           = "Синоними"
+    Locale["sr"]["examples"]           = "Примери"
+    Locale["sr"]["see-also"]           = "Погледајте такође"
+    Locale["sr"]["family"]             = "Indo-European"
+    Locale["sr"]["iso"]                = "srp"
+    Locale["sr"]["glotto"]             = "serb1264"
+    Locale["sr"]["script"]             = "Cyrl"
 
-    #69 Sesotho
-    Locale["st"]["name"]       = "Sesotho"
-    Locale["st"]["endonym"]    = "Sesotho"
-    Locale["st"]["message"]    = "Liphetolelo tsa %s"
+    #69 Sesotho (Southern Sotho)
+    Locale["st"]["name"]               = "Sesotho"
+    Locale["st"]["endonym"]            = "Sesotho"
+    Locale["st"]["translations-of"]    = "Liphetolelo tsa %s"
+    Locale["st"]["definitions-of"]     = "Meelelo ea %s"
+    Locale["st"]["synonyms"]           = "Mantsoe a tšoanang ka moelelo"
+    Locale["st"]["examples"]           = "Mehlala"
+    Locale["st"]["see-also"]           = "Bona hape"
+    Locale["st"]["family"]             = "Atlantic-Congo"
+    Locale["st"]["iso"]                = "sot"
+    Locale["st"]["glotto"]             = "sout2807"
+    Locale["st"]["script"]             = "Latn"
 
     #70 Sinhala
-    Locale["si"]["name"]       = "Sinhala"
-    Locale["si"]["endonym"]    = "සිංහල"
-    Locale["si"]["message"]    = "%s හි පරිවර්තන"
+    Locale["si"]["name"]               = "Sinhala"
+    Locale["si"]["endonym"]            = "සිංහල"
+    Locale["si"]["translations-of"]    = "%s හි පරිවර්තන"
+    Locale["si"]["definitions-of"]     = "%s හි නිර්වචන"
+    Locale["si"]["synonyms"]           = "සමානාර්ථ පද"
+    Locale["si"]["examples"]           = "උදාහරණ"
+    Locale["si"]["see-also"]           = "මෙයත් බලන්න"
+    Locale["si"]["family"]             = "Indo-European"
+    Locale["si"]["iso"]                = "sin"
+    Locale["si"]["glotto"]             = "sinh1246"
+    Locale["si"]["script"]             = "Sinh"
 
     #71 Slovak
-    Locale["sk"]["name"]       = "Slovak"
-    Locale["sk"]["endonym"]    = "Slovenčina"
-    Locale["sk"]["message"]    = "Preklady výrazu: %s"
+    Locale["sk"]["name"]               = "Slovak"
+    Locale["sk"]["endonym"]            = "Slovenčina"
+    Locale["sk"]["translations-of"]    = "Preklady výrazu: %s"
+    Locale["sk"]["definitions-of"]     = "Definície výrazu %s"
+    Locale["sk"]["synonyms"]           = "Synonymá"
+    Locale["sk"]["examples"]           = "Príklady"
+    Locale["sk"]["see-also"]           = "Pozrite tiež"
+    Locale["sk"]["family"]             = "Indo-European"
+    Locale["sk"]["iso"]                = "slk"
+    Locale["sk"]["glotto"]             = "slov1269"
+    Locale["sk"]["script"]             = "Latn"
 
-    #72 Slovenian
-    Locale["sl"]["name"]       = "Slovenian"
-    Locale["sl"]["endonym"]    = "Slovenščina"
-    Locale["sl"]["message"]    = "Prevodi za %s"
+    #72 Slovenian / Slovene
+    Locale["sl"]["name"]               = "Slovenian"
+    Locale["sl"]["endonym"]            = "Slovenščina"
+    Locale["sl"]["translations-of"]    = "Prevodi za %s"
+    Locale["sl"]["definitions-of"]     = "Razlage za %s"
+    Locale["sl"]["synonyms"]           = "Sopomenke"
+    Locale["sl"]["examples"]           = "Primeri"
+    Locale["sl"]["see-also"]           = "Glejte tudi"
+    Locale["sl"]["family"]             = "Indo-European"
+    Locale["sl"]["iso"]                = "slv"
+    Locale["sl"]["glotto"]             = "slov1268"
+    Locale["sl"]["script"]             = "Latn"
 
     #73 Somali
-    Locale["so"]["name"]       = "Somali"
-    Locale["so"]["endonym"]    = "Soomaali"
-    Locale["so"]["message"]    = "Turjumaada %s"
+    Locale["so"]["name"]               = "Somali"
+    Locale["so"]["endonym"]            = "Soomaali"
+    Locale["so"]["translations-of"]    = "Turjumaada %s"
+    Locale["so"]["definitions-of"]     = "Qeexitaannada %s"
+    Locale["so"]["synonyms"]           = "La micne ah"
+    Locale["so"]["examples"]           = "Tusaalooyin"
+    Locale["so"]["see-also"]           = "Sidoo kale eeg"
+    Locale["so"]["family"]             = "Afro-Asiatic"
+    Locale["so"]["iso"]                = "som"
+    Locale["so"]["glotto"]             = "soma1255"
+    Locale["so"]["script"]             = "Latn"
 
     #74 Spanish
-    Locale["es"]["name"]       = "Spanish"
-    Locale["es"]["endonym"]    = "Español"
-    Locale["es"]["message"]    = "Traducciones de %s"
+    Locale["es"]["name"]               = "Spanish"
+    Locale["es"]["endonym"]            = "Español"
+    Locale["es"]["translations-of"]    = "Traducciones de %s"
+    Locale["es"]["definitions-of"]     = "Definiciones de %s"
+    Locale["es"]["synonyms"]           = "Sinónimos"
+    Locale["es"]["examples"]           = "Ejemplos"
+    Locale["es"]["see-also"]           = "Ver también"
+    Locale["es"]["family"]             = "Indo-European"
+    Locale["es"]["iso"]                = "spa"
+    Locale["es"]["glotto"]             = "stan1288"
+    Locale["es"]["script"]             = "Latn"
 
-    #75 Sundanese (Latin alphabet)
-    Locale["su"]["name"]       = "Sundanese"
-    Locale["su"]["endonym"]    = "Basa Sunda"
-    Locale["su"]["message"]    = "Tarjamahan tina %s"
+    #75 Sundanese, Latin alphabet
+    Locale["su"]["name"]               = "Sundanese"
+    Locale["su"]["endonym"]            = "Basa Sunda"
+    Locale["su"]["translations-of"]    = "Tarjamahan tina %s"
+    Locale["su"]["definitions-of"]     = "Panjelasan tina %s"
+    Locale["su"]["synonyms"]           = "Sinonim"
+    Locale["su"]["examples"]           = "Conto"
+    Locale["su"]["see-also"]           = "Tingali ogé"
+    Locale["su"]["family"]             = "Austronesian"
+    Locale["su"]["iso"]                = "sun"
+    Locale["su"]["glotto"]             = "sund1252"
+    Locale["su"]["script"]             = "Latn"
 
     #76 Swahili
-    Locale["sw"]["name"]       = "Swahili"
-    Locale["sw"]["endonym"]    = "Kiswahili"
-    Locale["sw"]["message"]    = "Tafsiri ya %s"
+    Locale["sw"]["name"]               = "Swahili"
+    Locale["sw"]["endonym"]            = "Kiswahili"
+    Locale["sw"]["translations-of"]    = "Tafsiri ya %s"
+    Locale["sw"]["definitions-of"]     = "Ufafanuzi wa %s"
+    Locale["sw"]["synonyms"]           = "Visawe"
+    Locale["sw"]["examples"]           = "Mifano"
+    Locale["sw"]["see-also"]           = "Angalia pia"
+    Locale["sw"]["family"]             = "Atlantic-Congo"
+    Locale["sw"]["iso"]                = "swa"
+    Locale["sw"]["glotto"]             = "swah1253"
+    Locale["sw"]["script"]             = "Latn"
 
     #77 Swedish
-    Locale["sv"]["name"]       = "Swedish"
-    Locale["sv"]["endonym"]    = "Svenska"
-    Locale["sv"]["message"]    = "Översättningar av %s"
+    Locale["sv"]["name"]               = "Swedish"
+    Locale["sv"]["endonym"]            = "Svenska"
+    Locale["sv"]["translations-of"]    = "Översättningar av %s"
+    Locale["sv"]["definitions-of"]     = "Definitioner av %s"
+    Locale["sv"]["synonyms"]           = "Synonymer"
+    Locale["sv"]["examples"]           = "Exempel"
+    Locale["sv"]["see-also"]           = "Se även"
+    Locale["sv"]["family"]             = "Indo-European"
+    Locale["sv"]["iso"]                = "swe"
+    Locale["sv"]["glotto"]             = "swed1254"
+    Locale["sv"]["script"]             = "Latn"
 
-    #78 Tajik (Cyrillic alphabet)
-    Locale["tg"]["name"]       = "Tajik"
-    Locale["tg"]["endonym"]    = "Тоҷикӣ"
-    Locale["tg"]["message"]    = "Тарҷумаҳои %s"
+    #78 Tajik, Cyrillic alphabet
+    Locale["tg"]["name"]               = "Tajik"
+    Locale["tg"]["endonym"]            = "Тоҷикӣ"
+    Locale["tg"]["translations-of"]    = "Тарҷумаҳои %s"
+    Locale["tg"]["definitions-of"]     = "Таърифҳои %s"
+    Locale["tg"]["synonyms"]           = "Муродифҳо"
+    Locale["tg"]["examples"]           = "Намунаҳо:"
+    Locale["tg"]["see-also"]           = "Ҳамчунин Бинед"
+    Locale["tg"]["family"]             = "Indo-European"
+    Locale["tg"]["iso"]                = "tgk"
+    Locale["tg"]["glotto"]             = "taji1245"
+    Locale["tg"]["script"]             = "Cyrl"
 
     #79 Tamil
-    Locale["ta"]["name"]       = "Tamil"
-    Locale["ta"]["endonym"]    = "தமிழ்"
-    Locale["ta"]["message"]    = "%s இன் மொழிபெயர்ப்புகள்"
+    Locale["ta"]["name"]               = "Tamil"
+    Locale["ta"]["endonym"]            = "தமிழ்"
+    Locale["ta"]["translations-of"]    = "%s இன் மொழிபெயர்ப்புகள்"
+    Locale["ta"]["definitions-of"]     = "%s இன் வரையறைகள்"
+    Locale["ta"]["synonyms"]           = "இணைச்சொற்கள்"
+    Locale["ta"]["examples"]           = "எடுத்துக்காட்டுகள்"
+    Locale["ta"]["see-also"]           = "இதையும் காண்க"
+    Locale["ta"]["family"]             = "Dravidian"
+    Locale["ta"]["iso"]                = "tam"
+    Locale["ta"]["glotto"]             = "tami1289"
+    Locale["ta"]["script"]             = "Taml"
 
     #80 Telugu
-    Locale["te"]["name"]       = "Telugu"
-    Locale["te"]["endonym"]    = "తెలుగు"
-    Locale["te"]["message"]    = "%s యొక్క అనువాదాలు"
+    Locale["te"]["name"]               = "Telugu"
+    Locale["te"]["endonym"]            = "తెలుగు"
+    Locale["te"]["translations-of"]    = "%s యొక్క అనువాదాలు"
+    Locale["te"]["definitions-of"]     = "%s యొక్క నిర్వచనాలు"
+    Locale["te"]["synonyms"]           = "పర్యాయపదాలు"
+    Locale["te"]["examples"]           = "ఉదాహరణలు"
+    Locale["te"]["see-also"]           = "వీటిని కూడా చూడండి"
+    Locale["te"]["family"]             = "Dravidian"
+    Locale["te"]["iso"]                = "tel"
+    Locale["te"]["glotto"]             = "telu1262"
+    Locale["te"]["script"]             = "Telu"
 
     #81 Thai
-    Locale["th"]["name"]       = "Thai"
-    Locale["th"]["endonym"]    = "ไทย"
-    Locale["th"]["message"]    = "คำแปลของ %s"
+    Locale["th"]["name"]               = "Thai"
+    Locale["th"]["endonym"]            = "ไทย"
+    Locale["th"]["translations-of"]    = "คำแปลของ %s"
+    Locale["th"]["definitions-of"]     = "คำจำกัดความของ %s"
+    Locale["th"]["synonyms"]           = "คำพ้องความหมาย"
+    Locale["th"]["examples"]           = "ตัวอย่าง"
+    Locale["th"]["see-also"]           = "ดูเพิ่มเติม"
+    Locale["th"]["family"]             = "Tai–Kadai"
+    Locale["th"]["iso"]                = "tha"
+    Locale["th"]["glotto"]             = "thai1261"
+    Locale["th"]["script"]             = "Thai"
 
     #82 Turkish
-    Locale["tr"]["name"]       = "Turkish"
-    Locale["tr"]["endonym"]    = "Türkçe"
-    Locale["tr"]["message"]    = "%s çevirileri"
+    Locale["tr"]["name"]               = "Turkish"
+    Locale["tr"]["endonym"]            = "Türkçe"
+    Locale["tr"]["translations-of"]    = "%s çevirileri"
+    Locale["tr"]["definitions-of"]     = "%s için tanımlar"
+    Locale["tr"]["synonyms"]           = "Eş anlamlılar"
+    Locale["tr"]["examples"]           = "Örnekler"
+    Locale["tr"]["see-also"]           = "Ayrıca bkz."
+    Locale["tr"]["family"]             = "Turkic"
+    Locale["tr"]["iso"]                = "tur"
+    Locale["tr"]["glotto"]             = "nucl1301"
+    Locale["tr"]["script"]             = "Latn"
 
     #83 Ukrainian
-    Locale["uk"]["name"]       = "Ukrainian"
-    Locale["uk"]["endonym"]    = "Українська"
-    Locale["uk"]["message"]    = "Переклади слова або виразу \"%s\""
+    Locale["uk"]["name"]               = "Ukrainian"
+    Locale["uk"]["endonym"]            = "Українська"
+    Locale["uk"]["translations-of"]    = "Переклади слова або виразу \"%s\""
+    Locale["uk"]["definitions-of"]     = "\"%s\" – визначення"
+    Locale["uk"]["synonyms"]           = "Синоніми"
+    Locale["uk"]["examples"]           = "Приклади"
+    Locale["uk"]["see-also"]           = "Дивіться також"
+    Locale["uk"]["family"]             = "Indo-European"
+    Locale["uk"]["iso"]                = "ukr"
+    Locale["uk"]["glotto"]             = "ukra1253"
+    Locale["uk"]["script"]             = "Cyrl"
 
     #84 Urdu
-    Locale["ur"]["name"]       = "Urdu"
-    Locale["ur"]["endonym"]    = "اُردُو"
-    Locale["ur"]["message"]    = "کے ترجمے %s"
-    Locale["ur"]["rtl"]        = "true" # RTL language
+    Locale["ur"]["name"]               = "Urdu"
+    Locale["ur"]["endonym"]            = "اُردُو"
+    Locale["ur"]["translations-of"]    = "کے ترجمے %s"
+    Locale["ur"]["definitions-of"]     = "کی تعریفات %s"
+    Locale["ur"]["synonyms"]           = "مترادفات"
+    Locale["ur"]["examples"]           = "مثالیں"
+    Locale["ur"]["see-also"]           = "نیز دیکھیں"
+    Locale["ur"]["family"]             = "Indo-European"
+    Locale["ur"]["iso"]                = "urd"
+    Locale["ur"]["glotto"]             = "urdu1245"
+    Locale["ur"]["script"]             = "Arab"
+    Locale["ur"]["rtl"]                = "true" # RTL language
 
-    #85 Uzbek (Latin alphabet)
-    Locale["uz"]["name"]       = "Uzbek"
-    Locale["uz"]["endonym"]    = "Oʻzbek tili"
-    Locale["uz"]["message"]    = "%s tarjimalari"
+    #85 Uzbek, Latin alphabet
+    Locale["uz"]["name"]               = "Uzbek"
+    Locale["uz"]["endonym"]            = "Oʻzbek tili"
+    Locale["uz"]["translations-of"]    = "%s: tarjima variantlari"
+    Locale["uz"]["definitions-of"]     = "%s – ta’riflar"
+    Locale["uz"]["synonyms"]           = "Sinonimlar"
+    Locale["uz"]["examples"]           = "Namunalar"
+    Locale["uz"]["see-also"]           = "O‘xshash so‘zlar"
+    Locale["uz"]["family"]             = "Turkic"
+    Locale["uz"]["iso"]                = "uzb"
+    Locale["uz"]["glotto"]             = "uzbe1247"
+    Locale["uz"]["script"]             = "Latn"
 
     #86 Vietnamese
-    Locale["vi"]["name"]       = "Vietnamese"
-    Locale["vi"]["endonym"]    = "Tiếng Việt"
-    Locale["vi"]["message"]    = "Bản dịch của %s"
+    Locale["vi"]["name"]               = "Vietnamese"
+    Locale["vi"]["endonym"]            = "Tiếng Việt"
+    Locale["vi"]["translations-of"]    = "Bản dịch của %s"
+    Locale["vi"]["definitions-of"]     = "Nghĩa của %s"
+    Locale["vi"]["synonyms"]           = "Từ đồng nghĩa"
+    Locale["vi"]["examples"]           = "Ví dụ"
+    Locale["vi"]["see-also"]           = "Xem thêm"
+    Locale["vi"]["family"]             = "Austroasiatic"
+    Locale["vi"]["iso"]                = "vie"
+    Locale["vi"]["glotto"]             = "viet1252"
+    Locale["vi"]["script"]             = "Latn"
 
     #87 Welsh
-    Locale["cy"]["name"]       = "Welsh"
-    Locale["cy"]["endonym"]    = "Cymraeg"
-    Locale["cy"]["message"]    = "Cyfieithiadau %s"
+    Locale["cy"]["name"]               = "Welsh"
+    Locale["cy"]["endonym"]            = "Cymraeg"
+    Locale["cy"]["translations-of"]    = "Cyfieithiadau %s"
+    Locale["cy"]["definitions-of"]     = "Diffiniadau %s"
+    Locale["cy"]["synonyms"]           = "Cyfystyron"
+    Locale["cy"]["examples"]           = "Enghreifftiau"
+    Locale["cy"]["see-also"]           = "Gweler hefyd"
+    Locale["cy"]["family"]             = "Indo-European"
+    Locale["cy"]["iso"]                = "cym"
+    Locale["cy"]["glotto"]             = "wels1247"
+    Locale["cy"]["script"]             = "Latn"
 
     #88 Yiddish
-    Locale["yi"]["name"]       = "Yiddish"
-    Locale["yi"]["endonym"]    = "ייִדיש"
-    Locale["yi"]["message"]    = "איבערזעצונגען פון %s"
-    Locale["yi"]["rtl"]        = "true" # RTL language
+    Locale["yi"]["name"]               = "Yiddish"
+    Locale["yi"]["endonym"]            = "ייִדיש"
+    Locale["yi"]["translations-of"]    = "איבערזעצונגען פון %s"
+    Locale["yi"]["definitions-of"]     = "דפיניציונען %s"
+    Locale["yi"]["synonyms"]           = "סינאָנימען"
+    Locale["yi"]["examples"]           = "ביישפילע"
+    Locale["yi"]["see-also"]           = "זייען אויך"
+    Locale["yi"]["family"]             = "Indo-European"
+    Locale["yi"]["iso"]                = "yid"
+    Locale["yi"]["glotto"]             = "yidd1255"
+    Locale["yi"]["script"]             = "Hebr"
+    Locale["yi"]["rtl"]                = "true" # RTL language
 
     #89 Yoruba
-    Locale["yo"]["name"]       = "Yoruba"
-    Locale["yo"]["endonym"]    = "Yorùbá"
-    Locale["yo"]["message"]    = "Awọn itumọ ti %s"
+    Locale["yo"]["name"]               = "Yoruba"
+    Locale["yo"]["endonym"]            = "Yorùbá"
+    Locale["yo"]["translations-of"]    = "Awọn itumọ ti %s"
+    Locale["yo"]["definitions-of"]     = "Awọn itumọ ti %s"
+    Locale["yo"]["synonyms"]           = "Awọn ọrọ onitumọ"
+    Locale["yo"]["examples"]           = "Awọn apẹrẹ"
+    Locale["yo"]["see-also"]           = "Tun wo"
+    Locale["yo"]["family"]             = "Atlantic-Congo"
+    Locale["yo"]["iso"]                = "yor"
+    Locale["yo"]["glotto"]             = "yoru1245"
+    Locale["yo"]["script"]             = "Latn"
 
     #90 Zulu
-    Locale["zu"]["name"]       = "Zulu"
-    Locale["zu"]["endonym"]    = "isiZulu"
-    Locale["zu"]["message"]    = "Ukuhumusha i-%s"
+    Locale["zu"]["name"]               = "Zulu"
+    Locale["zu"]["endonym"]            = "isiZulu"
+    Locale["zu"]["translations-of"]    = "Ukuhumusha i-%s"
+    Locale["zu"]["definitions-of"]     = "Izincazelo ze-%s"
+    Locale["zu"]["synonyms"]           = "Amagama afanayo"
+    Locale["zu"]["examples"]           = "Izibonelo"
+    Locale["zu"]["see-also"]           = "Bheka futhi"
+    Locale["zu"]["family"]             = "Atlantic-Congo"
+    Locale["zu"]["iso"]                = "zul"
+    Locale["zu"]["glotto"]             = "zulu1248"
+    Locale["zu"]["script"]             = "Latn"
 
     # Aliases for some locales
     # See: <http://www.loc.gov/standards/iso639-2/php/code_changes.php>
     LocaleAlias["in"] = "id" # withdrawn language code for Indonesian
     LocaleAlias["iw"] = "he" # withdrawn language code for Hebrew
     LocaleAlias["ji"] = "yi" # withdrawn language code for Yiddish
-
     LocaleAlias["jw"] = "jv" # withdrawn language code for Javanese
     LocaleAlias["mo"] = "ro" # Moldavian or Moldovan considered a variant of the Romanian language
-    LocaleAlias["sh"] = "sr" # Serbo-Croatian: prefer Serbian
-    LocaleAlias["zh"] = "zh-CN" # Chinese: prefer Chinese Simplified
-    LocaleAlias["zh-cn"] = "zh-CN" # lowercase
-    LocaleAlias["zh-tw"] = "zh-TW" # lowercase
-    # TODO: any more aliases supported by Google Translate?
+    LocaleAlias["sh"] = "sr" # Serbo-Croatian: default to Serbian
+    LocaleAlias["zh"] = "zh-CN" # Chinese: default to Chinese Simplified
 }
 
 # Get locale key by language code or alias.
 function getCode(code) {
-    code = tolower(code) # case-insensitive
-
-    if (code in Locale || code == "auto")
+    if (code == "auto" || code in Locale)
         return code
     else if (code in LocaleAlias)
         return LocaleAlias[code]
     else
         return # return nothing if not found
+}
+
+# Return the name of a language.
+function getName(code) {
+    return Locale[getCode(code)]["name"]
+}
+
+# Return the endonym of a language.
+function getEndonym(code) {
+    return Locale[getCode(code)]["endonym"]
+}
+
+# Return formatted text for "translations of".
+function showTranslationsOf(code, text,    fmt) {
+    fmt = Locale[getCode(code)]["translations-of"]
+    if (!fmt) fmt = Locale["en"]["translations-of"]
+    return sprintf(fmt, text)
+}
+
+# Return formatted text for "definitions of".
+function showDefinitionsOf(code, text,    fmt) {
+    fmt = Locale[getCode(code)]["definitions-of"]
+    if (!fmt) fmt = Locale["en"]["definitions-of"]
+    return sprintf(fmt, text)
+}
+
+# Return a string of "synonyms".
+function showSynonyms(code,    tmp) {
+    tmp = Locale[getCode(code)]["synonyms"]
+    if (!tmp) tmp = Locale["en"]["synonyms"]
+    return tmp
+}
+
+# Return a string of "examples".
+function showExamples(code,    tmp) {
+    tmp = Locale[getCode(code)]["examples"]
+    if (!tmp) tmp = Locale["en"]["examples"]
+    return tmp
+}
+
+# Return a string of "see also".
+function showSeeAlso(code,    tmp) {
+    tmp = Locale[getCode(code)]["see-also"]
+    if (!tmp) tmp = Locale["en"]["see-also"]
+    return tmp
+}
+
+# Return the family of a language.
+function getFamily(code) {
+    return Locale[getCode(code)]["family"]
+}
+
+# Return the ISO 639-3 code of a language.
+function getISO(code) {
+    return Locale[getCode(code)]["iso"]
+}
+
+# Return the Glottocode of a language.
+function getGlotto(code) {
+    return Locale[getCode(code)]["glotto"]
+}
+
+# Return the ISO 15924 script code of a language.
+function getScript(code) {
+    return Locale[getCode(code)]["script"]
+}
+
+# Return 1 if a language is R-to-L; otherwise return 0.
+function isRTL(code) {
+    return Locale[getCode(code)]["rtl"] ? 1 : 0
 }
 
 # Detect external bidirectional algorithm utility (fribidi);
@@ -503,14 +1301,14 @@ function initBiDi() {
     BiDi = FriBidi ? "fribidi --width %s" : "rev | sed \"s/'/\\\\\\'/\" | xargs printf '%%s '"
 }
 
-# Add /slashes/ for IPA phonemic notations
+# Add /slashes/ for IPA phonemic notations and (parentheses) for others.
 # Parameters:
 #     code
 function showPhonetics(phonetics, code) {
     if (code && getCode(code) == "en")
         return "/" phonetics "/"
     else
-        return phonetics
+        return "(" phonetics ")"
 }
 
 # Convert a logical string to visual; don't right justify RTL lines.
@@ -551,6 +1349,23 @@ function s(text, code, width,    temp) {
         return text
 }
 
+# Convert a logical string to visual with a certain level of indentation.
+# Parameters:
+#     level: level of indentation
+#     code: ignore to apply left indentation
+#     width: ignore to use default width for padding
+function ins(level, text, code, width,    i, temp) {
+    if (code && Locale[getCode(code)]["rtl"]) {
+        if (!width) width = Option["width"]
+        return s(text, code, width - level * length(I))
+    } else {
+        temp = ""
+        for (i = 0; i < level; i++)
+            temp = temp I
+        return temp text
+    }
+}
+
 # Initialize strings for displaying endonyms of locales.
 function initLocaleDisplay(    i) {
     for (i in Locale)
@@ -587,5 +1402,5 @@ function initUserLang() {
          "en")
 
     if (tolower(ENVIRON["LANG"]) !~ /utf-?8$/ && tolower(ENVIRON["LC_CTYPE"]) !~ /utf-?8$/)
-        w("[WARNING] Your locale codeset (" ENVIRON["LANG"] ") is not UTF-8. You have been warned.")
+        w("[WARNING] Your locale codeset (" ENVIRON["LANG"] ") is not UTF-8.")
 }

--- a/include/Languages.awk
+++ b/include/Languages.awk
@@ -503,6 +503,16 @@ function initBiDi() {
     BiDi = FriBidi ? "fribidi --width %s" : "rev | sed \"s/'/\\\\\\'/\" | xargs printf '%%s '"
 }
 
+# Add /slashes/ for IPA phonemic notations
+# Parameters:
+#     code
+function showPhonetics(phonetics, code) {
+    if (code && getCode(code) == "en")
+        return "/" phonetics "/"
+    else
+        return phonetics
+}
+
 # Convert a logical string to visual; don't right justify RTL lines.
 # Parameters:
 #     code: ignore to apply bidirectional algorithm on every string

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -25,7 +25,7 @@ function preInit() {
     initUserLang()      #<< Locale
 
     RS = "\n"
-    I  = "  "
+    I  = "    "
 
     ExitCode = 0
 

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -25,6 +25,7 @@ function preInit() {
     initUserLang()      #<< Locale
 
     RS = "\n"
+    I  = "  "
 
     ExitCode = 0
 

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -116,8 +116,8 @@ BEGIN {
             exit
         }
 
-        # -d, -debug
-        match(ARGV[pos], /^--?d(e(b(ug?)?)?)?$/)
+        # -D, -debug
+        match(ARGV[pos], /^--?(debug|D)$/)
         if (RSTART) {
             Option["debug"] = 1
             continue

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -207,7 +207,7 @@ function getTranslation(text, sl, tl, hl,
         if (wordMode) {
             r = AnsiCode["bold"] show(join(original), il) AnsiCode["no bold"]
             if (anything(oPhonetics))
-                r = r "\n" AnsiCode["bold"] "/" join(oPhonetics) "/" AnsiCode["no bold"]
+                r = r "\n" AnsiCode["bold"] showPhonetics(join(oPhonetics), il) AnsiCode["no bold"]
         }
         if (dictMode) {
             # Dictionary mode
@@ -271,7 +271,7 @@ function getTranslation(text, sl, tl, hl,
         if (!wordMode) {
             r = r AnsiCode["bold"] s(translation, tl) AnsiCode["no bold"] # target language
             if (anything(phonetics))
-                r = r "\n" AnsiCode["bold"] "/" join(phonetics) "/" AnsiCode["no bold"] # phonetic transcription
+                r = r "\n" AnsiCode["bold"] showPhonetics(join(phonetics), tl) AnsiCode["no bold"] # phonetic transcription
         }
 
         if (isarray(altTranslations[0]) && anything(altTranslations[0])) {
@@ -291,7 +291,7 @@ function getTranslation(text, sl, tl, hl,
             if (wordMode) {
                 r = r "\n" AnsiCode["bold"] s(translation, tl) AnsiCode["no bold"] # target language
                 if (anything(phonetics))
-                    r = r "\n" AnsiCode["bold"] "/" join(phonetics) "/" AnsiCode["no bold"] # phonetic transcription
+                    r = r "\n" AnsiCode["bold"] showPhonetics(join(phonetics), tl) AnsiCode["no bold"] # phonetic transcription
             } else {
                 temp = segments[0] "(" join(altTranslations[0], "/") ")"
                 for (i = 1; i < length(altTranslations); i++)

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -199,19 +199,20 @@ function getTranslation(text, sl, tl, hl,
     } else {
         # Verbose mode
 
-        if (isarray(wordClasses) && anything(wordClasses))
+        if (isarray(wordClasses))
             wordMode = 1
-        if (il == tl)
+        if (il == tl && isarray(oWordClasses))
             wordMode = dictMode = 1
 
         if (wordMode) {
             r = AnsiCode["bold"] show(join(original), il) AnsiCode["no bold"]
             if (anything(oPhonetics))
                 r = r "\n" AnsiCode["bold"] "/" join(oPhonetics) "/" AnsiCode["no bold"]
-            r = r "\n"
         }
         if (dictMode) {
             # Dictionary mode
+            r = r "\n"
+
             if (isarray(oWordClasses) && anything(oWordClasses)) {
                 for (i = 0; i < length(oWordClasses); i++) {
                     r = r "\n" AnsiCode["negative"] AnsiCode["bold"]    \
@@ -271,11 +272,11 @@ function getTranslation(text, sl, tl, hl,
             r = r AnsiCode["bold"] s(translation, tl) AnsiCode["no bold"] # target language
             if (anything(phonetics))
                 r = r "\n" AnsiCode["bold"] "/" join(phonetics) "/" AnsiCode["no bold"] # phonetic transcription
-            r = r "\n"
         }
 
         if (isarray(altTranslations[0]) && anything(altTranslations[0])) {
             # List alternative translations
+            r = r "\n"
 
             if (Locale[getCode(hl)]["rtl"] || Locale[getCode(il)]["rtl"])
                 r = r "\n" s(sprintf(Locale[getCode(hl)]["message"], "\"" join(original) "\"")) ":" # caution: mixed languages, BiDi invoked must be implemented correctly (i.e. FriBidi is required)

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -307,7 +307,8 @@ function getTranslation(text, sl, tl, hl,
             # List dictionary entries
 
             for (i = 0; i < length(wordClasses); i++) {
-                r = r "\n\n" s(AnsiCode["negative"] wordClasses[i] AnsiCode["positive"], hl) # home language
+                r = r "\n\n" s(AnsiCode["negative"] AnsiCode["bold"]    \
+                               wordClasses[i] AnsiCode["no bold"] AnsiCode["positive"], hl) # home language
                 for (j = 0; j < length(words[i]); j++) {
                     word = words[i][j][0]
                     explanation = join(words[i][j][1], ", ")

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -199,97 +199,114 @@ function getTranslation(text, sl, tl, hl,
     } else {
         # Verbose mode
 
-        r = AnsiCode["bold"] show(join(original), il) AnsiCode["no bold"]
-        if (anything(oPhonetics))
-            r = r "\n" AnsiCode["bold"] "/" join(oPhonetics) "/" AnsiCode["no bold"]
-        r = r "\n"
-        # Dictionary mode
-        if (isarray(oWordClasses) && anything(oWordClasses)) {
-            for (i = 0; i < length(oWordClasses); i++) {
-                r = r "\n" AnsiCode["negative"] AnsiCode["bold"]        \
-                    show(oWordClasses[i], hl) AnsiCode["no bold"] AnsiCode["positive"]
-                if (isarray(oWords[i])) {
-                    # Detailed explanation
-                    for (j = 0; j < length(oWords[i]); j++) {
-                        explanation = oWords[i][j][0]
-                        ref = oWords[i][j][1]
-                        example = oWords[i][j][2]
+        if (isarray(wordClasses) && anything(wordClasses))
+            wordMode = 1
+        if (il == tl)
+            wordMode = dictMode = 1
 
-                        r = r "\n    " AnsiCode["bold"] show(explanation, il) AnsiCode["no bold"]
-                        if (example)
-                            r = r "\n    - \"" show(example, il) "\""
-                        if (ref && isarray(oRefs[ref])) {
-                            r = r "\n    * synonyms: " AnsiCode["underline"] \
-                                show(oSynonyms[oRefs[ref][1]][oRefs[ref][2]][0], il) AnsiCode["no underline"]
-                            for (k = 1; k < length(oSynonyms[oRefs[ref][1]][oRefs[ref][2]]); k++)
-                                r = r ", " AnsiCode["underline"]        \
-                                    show(oSynonyms[oRefs[ref][1]][oRefs[ref][2]][k], il) AnsiCode["no underline"]
+        if (wordMode) {
+            r = AnsiCode["bold"] show(join(original), il) AnsiCode["no bold"]
+            if (anything(oPhonetics))
+                r = r "\n" AnsiCode["bold"] "/" join(oPhonetics) "/" AnsiCode["no bold"]
+            r = r "\n"
+        }
+        if (dictMode) {
+            # Dictionary mode
+            if (isarray(oWordClasses) && anything(oWordClasses)) {
+                for (i = 0; i < length(oWordClasses); i++) {
+                    r = r "\n" AnsiCode["negative"] AnsiCode["bold"]    \
+                        show(oWordClasses[i], hl) AnsiCode["no bold"] AnsiCode["positive"]
+                    if (isarray(oWords[i])) {
+                        # Detailed explanation
+                        for (j = 0; j < length(oWords[i]); j++) {
+                            explanation = oWords[i][j][0]
+                            ref = oWords[i][j][1]
+                            example = oWords[i][j][2]
+
+                            r = r "\n    " AnsiCode["bold"] show(explanation, il) AnsiCode["no bold"]
+                            if (example)
+                                r = r "\n    - \"" show(example, il) "\""
+                            if (ref && isarray(oRefs[ref])) {
+                                r = r "\n    * synonyms: " AnsiCode["underline"] \
+                                    show(oSynonyms[oRefs[ref][1]][oRefs[ref][2]][0], il) AnsiCode["no underline"]
+                                for (k = 1; k < length(oSynonyms[oRefs[ref][1]][oRefs[ref][2]]); k++)
+                                    r = r ", " AnsiCode["underline"]    \
+                                        show(oSynonyms[oRefs[ref][1]][oRefs[ref][2]][k], il) AnsiCode["no underline"]
+                            }
+                            r = r "\n"
+                        }
+                    } else {
+                        # Synonyms only
+                        for (j = 0; j < length(oSynonyms[i]); j++) {
+                            r = r "\n  * " show(oSynonyms[i][j][0], il)
+                            for (k = 1; k < length(oSynonyms[i][j]); k++)
+                                r = r ", " show(oSynonyms[i][j][k], il)
                         }
                         r = r "\n"
                     }
-                } else {
-                    # Synonyms only
-                    for (j = 0; j < length(oSynonyms[i]); j++) {
-                        r = r "\n  * " show(oSynonyms[i][j][0], il)
-                        for (k = 1; k < length(oSynonyms[i][j]); k++)
-                            r = r ", " show(oSynonyms[i][j][k], il)
-                    }
+                }
+            }
+            # Examples
+            if (isarray(oExamples) && anything(oExamples)) {
+                r = r "\n" "Examples:"
+                for (i = 0; i < length(oExamples); i++) {
+                    example = oExamples[i]
+                    sub(/\u003cb\u003e/, AnsiCode["negative"], example)
+                    sub(/\u003c\/b\u003e/, AnsiCode["positive"], example)
+                    r = r "\n  - " show(example, il)
                     r = r "\n"
                 }
             }
-        }
-        # Examples
-        if (isarray(oExamples) && anything(oExamples)) {
-            r = r "\n" "Examples:"
-            for (i = 0; i < length(oExamples); i++) {
-                example = oExamples[i]
-                sub(/\u003cb\u003e/, AnsiCode["negative"], example)
-                sub(/\u003c\/b\u003e/, AnsiCode["positive"], example)
-                r = r "\n  - " show(example, il)
+            # See also
+            if (isarray(oSeeAlso) && anything(oSeeAlso)) {
+                r = r "\n" "See also:"
+                r = r "\n" AnsiCode["underline"] show(oSeeAlso[0], il) AnsiCode["no underline"]
+                for (k = 1; k < length(oSeeAlso); k++)
+                    r = r ", " AnsiCode["underline"] show(oSeeAlso[k], il) AnsiCode["no underline"]
                 r = r "\n"
             }
         }
-        # See also
-        if (isarray(oSeeAlso) && anything(oSeeAlso)) {
-            r = r "\n" "See also:"
-            r = r "\n" AnsiCode["underline"] show(oSeeAlso[0], il) AnsiCode["no underline"]
-            for (k = 1; k < length(oSeeAlso); k++)
-                r = r ", " AnsiCode["underline"] show(oSeeAlso[k], il) AnsiCode["no underline"]
+
+        if (!wordMode) {
+            r = r AnsiCode["bold"] s(translation, tl) AnsiCode["no bold"] # target language
+            if (anything(phonetics))
+                r = r "\n" AnsiCode["bold"] "/" join(phonetics) "/" AnsiCode["no bold"] # phonetic transcription
             r = r "\n"
         }
-
-
-
-        r = r "\n" AnsiCode["bold"] s(translation, tl) AnsiCode["no bold"] # target language
-        if (anything(phonetics))
-            r = r "\n" AnsiCode["bold"] join(phonetics) AnsiCode["no bold"] # phonetic transcription
 
         if (isarray(altTranslations[0]) && anything(altTranslations[0])) {
             # List alternative translations
 
             if (Locale[getCode(hl)]["rtl"] || Locale[getCode(il)]["rtl"])
-                r = r "\n\n" s(sprintf(Locale[getCode(hl)]["message"], join(original))) # caution: mixed languages, BiDi invoked must be implemented correctly (i.e. FriBidi is required)
+                r = r "\n" s(sprintf(Locale[getCode(hl)]["message"], "\"" join(original) "\"")) ":" # caution: mixed languages, BiDi invoked must be implemented correctly (i.e. FriBidi is required)
             else
-                r = r "\n\n" sprintf(Locale[getCode(hl)]["message"], join(original))
-            if (Locale[getCode(il)]["rtl"] || Locale[getCode(tl)]["rtl"])
-                r = r "\n" s("(" Locale[getCode(il)]["endonym"] " ➔ " Locale[getCode(tl)]["endonym"] ")") # caution: mixed languages
-            else
-                r = r "\n" "(" Locale[getCode(il)]["endonym"] " ➔ " Locale[getCode(tl)]["endonym"] ")"
+                r = r "\n" sprintf(Locale[getCode(hl)]["message"], "\"" join(original) "\"") ":"
 
-            temp = segments[0] "(" join(altTranslations[0], "/") ")"
-            for (i = 1; i < length(altTranslations); i++)
-                temp = temp " " segments[i] "(" join(altTranslations[i], "/") ")"
             if (Locale[getCode(il)]["rtl"] || Locale[getCode(tl)]["rtl"])
-                r = r "\n" AnsiCode["bold"] s(temp) AnsiCode["no bold"] # caution: mixed languages
+                r = r "\n" s("(" Locale[getCode(il)]["endonym"] " -> " Locale[getCode(tl)]["endonym"] ")") # caution: mixed languages
             else
-                r = r "\n" AnsiCode["bold"] temp AnsiCode["no bold"]
+                r = r "\n" "(" Locale[getCode(il)]["endonym"] " -> " Locale[getCode(tl)]["endonym"] ")"
+
+            if (wordMode) {
+                r = r "\n" AnsiCode["bold"] s(translation, tl) AnsiCode["no bold"] # target language
+                if (anything(phonetics))
+                    r = r "\n" AnsiCode["bold"] "/" join(phonetics) "/" AnsiCode["no bold"] # phonetic transcription
+            } else {
+                temp = segments[0] "(" join(altTranslations[0], "/") ")"
+                for (i = 1; i < length(altTranslations); i++)
+                    temp = temp " " segments[i] "(" join(altTranslations[i], "/") ")"
+                if (Locale[getCode(il)]["rtl"] || Locale[getCode(tl)]["rtl"])
+                    r = r "\n" AnsiCode["bold"] s(temp) AnsiCode["no bold"] # caution: mixed languages
+                else
+                    r = r "\n" AnsiCode["bold"] temp AnsiCode["no bold"]
+            }
         }
 
         if (isarray(wordClasses) && anything(wordClasses)) {
             # List dictionary entries
 
-            for (i = 0; i < length(words); i++) {
-                r = r "\n\n" s("[" wordClasses[i] "]", hl) # home language
+            for (i = 0; i < length(wordClasses); i++) {
+                r = r "\n\n" s(AnsiCode["negative"] wordClasses[i] AnsiCode["positive"], hl) # home language
                 for (j = 0; j < length(words[i]); j++) {
                     word = words[i][j][0]
                     explanation = join(words[i][j][1], ", ")


### PR DESCRIPTION
When source language is identical with target language, `trans` simply echoes the word back. This is not very helpful if one wants to find out more about the meaning of that word.

![screenshot from 2015-04-22 22 22 57](https://cloud.githubusercontent.com/assets/342945/7277831/c0cdadf0-e944-11e4-85a5-81cf7383a9e5.png)

Better if items in the dictionary can be shown instead: (whenever possible)

![screenshot from 2015-04-22 22 23 12](https://cloud.githubusercontent.com/assets/342945/7278043/cab3080a-e945-11e4-9cbc-2ac63509e011.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/translate-shell/51)

<!-- Reviewable:end -->
