### PR TITLE
Remove self-upgrading code

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In order to be happy, the best way is to be loved by people.
 * **[rlwrap](http://utopia.knoware.nl/~hlub/uck/rlwrap/#rlwrap)**: *a GNU readline wrapper*
     * required for readline-style editing and history in the interactive shell
 * **[curl](http://curl.haxx.se/)** with **OpenSSL** support
-    * required for secured URL fetching (self-upgrading, etc.)
+    * required for secured URL fetching (checking for upgrade, etc.)
 
 ### Environment and Fonts
 
@@ -306,14 +306,6 @@ You may specify the source language and the target language(s) before starting a
 
 You may also change these settings during an interactive session. See **[wiki: REPL](https://github.com/soimort/translate-shell/wiki/REPL)** for more advanced usage of the interactive Translate Shell.
 
-### Upgrading
-
-It is possible for the program to upgrade itself:
-
-    $ trans -U
-
-To enable this kind of upgrading, `curl` with OpenSSL must be installed on the system (since `gawk` does not come with SSL/TLS support).
-
 ## Usage
 
 For more details on command-line options, see the man page **[trans(1)](http://www.soimort.org/translate-shell/trans.1.html)** or use `trans -M` in a terminal.
@@ -335,7 +327,7 @@ Information options:
     -L CODES, -list CODES
         Print details of languages and exit.
     -U, -upgrade
-        Upgrade this program to latest version.
+        Check for upgrade of this program.
 
 Display options:
     -verbose

--- a/README.template.md
+++ b/README.template.md
@@ -78,7 +78,7 @@ In order to be happy, the best way is to be loved by people.
 * **[rlwrap](http://utopia.knoware.nl/~hlub/uck/rlwrap/#rlwrap)**: *a GNU readline wrapper*
     * required for readline-style editing and history in the interactive shell
 * **[curl](http://curl.haxx.se/)** with **OpenSSL** support
-    * required for secured URL fetching (self-upgrading, etc.)
+    * required for secured URL fetching (checking for upgrade, etc.)
 
 ### Environment and Fonts
 
@@ -305,14 +305,6 @@ You may specify the source language and the target language(s) before starting a
     $ trans -shell en:fr
 
 You may also change these settings during an interactive session. See **[wiki: REPL](https://github.com/soimort/translate-shell/wiki/REPL)** for more advanced usage of the interactive Translate Shell.
-
-### Upgrading
-
-It is possible for the program to upgrade itself:
-
-    $ trans -U
-
-To enable this kind of upgrading, `curl` with OpenSSL must be installed on the system (since `gawk` does not come with SSL/TLS support).
 
 ## Usage
 

--- a/build.awk
+++ b/build.awk
@@ -168,8 +168,6 @@ function build(target, type,    group, inline, line, temp) {
                 print "export TRANS_BUILD=git:" temp > Trans
         }
 
-        print "export TRANS_ABSPATH=$(cd \"$(dirname \"$0\")\" && pwd)/$(basename \"$0\")" > Trans
-
         print "export COLUMNS=$(tput cols)" > Trans
 
         print "gawk -f <(echo -E \"$TRANS_PROGRAM\") - \"$@\"" > Trans

--- a/include/Commons.awk
+++ b/include/Commons.awk
@@ -328,6 +328,11 @@ function w(text) {
 
 # Print error message.
 function e(text) {
+    print ansi("bold", ansi("yellow", text)) > STDERR
+}
+
+# What a terrible failure.
+function wtf(text) {
     print ansi("bold", ansi("red", text)) > STDERR
 }
 

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -55,7 +55,7 @@ function getHelp() {
             ", " ansi("bold", "-list ") ansi("underline", "CODES")) RS  \
         ins(2, "Print details of languages and exit.") RS               \
         ins(1, ansi("bold", "-U") ", " ansi("bold", "-upgrade")) RS     \
-        ins(2, "Upgrade this program to latest version.") RS            \
+        ins(2, "Check for upgrade of this program.") RS                 \
         RS "Display options:" RS                                        \
         ins(1, ansi("bold", "-verbose")) RS                             \
         ins(2, "Verbose mode. (default)") RS                            \

--- a/include/Script.awk
+++ b/include/Script.awk
@@ -43,25 +43,12 @@ function loadOptions(script,    i, j, tokens, name, value) {
 }
 
 # Upgrade script.
-function upgrade(    gitHead, i, newVersion, registry, tokens, trans) {
-    if (!ENVIRON["TRANS_ABSPATH"]) {
-        w("[ERROR] Not running from a single executable.")
-        gitHead = getGitHead()
-        if (gitHead)
-            w("        Please try to upgrade via git commands.")
-        else
-            w("        Please download the latest release from here:" RS \
-              "        https://github.com/soimort/translate-shell/releases")
-        ExitCode = 1
-        return
-    }
-
+function upgrade(    i, newVersion, registry, tokens) {
     RegistryIndex = "https://raw.githubusercontent.com/soimort/translate-shell/registry/index.trans"
-    TransExecutable = "http://www.soimort.org/translate-shell/trans"
 
     registry = curl(RegistryIndex)
     if (!registry) {
-        e("[ERROR] Upgrading failed.")
+        e("[ERROR] Failed to check for upgrade.")
         ExitCode = 1
         return
     }
@@ -71,13 +58,11 @@ function upgrade(    gitHead, i, newVersion, registry, tokens, trans) {
         if (tokens[i] == ":translate-shell")
             newVersion = literal(tokens[i + 1])
     if (newerVersion(newVersion, Version)) {
-        trans = curl(TransExecutable)
-        if (trans) {
-            print "Successfully upgraded to " newVersion "." > STDERR
-            print trans > ENVIRON["TRANS_ABSPATH"]
-            exit 0
-        } else
-            e("[ERROR] Upgrading failed due to network errors.")
-    } else
-        e("[ERROR] Already up-to-date.")
+        w("Current version: \t" Version)
+        w("New version available: \t" newVersion)
+        w("Download from: \t" "http://www.soimort.org/translate-shell/trans")
+    } else {
+        w("Current version: \t" Version)
+        w("Already up-to-date.")
+    }
 }

--- a/include/Script.awk
+++ b/include/Script.awk
@@ -42,7 +42,7 @@ function loadOptions(script,    i, j, tokens, name, value) {
     }
 }
 
-# Upgrade script.
+# Check for upgrade.
 function upgrade(    i, newVersion, registry, tokens) {
     RegistryIndex = "https://raw.githubusercontent.com/soimort/translate-shell/registry/index.trans"
 

--- a/man/trans.1
+++ b/man/trans.1
@@ -55,7 +55,7 @@ sign "+".
 .RE
 .TP
 .B \f[B]\-U\f[], \f[B]\-upgrade\f[]
-Upgrade this program to latest version.
+Check for upgrade of this program.
 .RS
 .RE
 .SS Display options

--- a/man/trans.1
+++ b/man/trans.1
@@ -1,4 +1,4 @@
-.TH "TRANS" "1" "2015\-05\-26" "0.9.0.3" ""
+.TH "TRANS" "1" "2015\-05\-26" "0.9.0.4" ""
 .SH NAME
 .PP
 trans \- Google Translate served as a command\-line tool

--- a/man/trans.1.md
+++ b/man/trans.1.md
@@ -1,4 +1,4 @@
-% TRANS(1) 0.9.0.3
+% TRANS(1) 0.9.0.4
 % Mort Yao <soi@mort.ninja>
 % 2015-05-26
 

--- a/man/trans.1.md
+++ b/man/trans.1.md
@@ -41,7 +41,7 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 :   Print details of languages and exit. When specifying two or more language codes, concatenate them by plus sign "+".
 
 **-U**, **-upgrade**
-:   Upgrade this program to latest version.
+:   Check for upgrade of this program.
 
 ## Display options
 

--- a/man/trans.1.template.md
+++ b/man/trans.1.template.md
@@ -41,7 +41,7 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 :   Print details of languages and exit. When specifying two or more language codes, concatenate them by plus sign "+".
 
 **-U**, **-upgrade**
-:   Upgrade this program to latest version.
+:   Check for upgrade of this program.
 
 ## Display options
 

--- a/metainfo.awk
+++ b/metainfo.awk
@@ -1,7 +1,7 @@
 BEGIN {
     Name        = "Translate Shell"
     Description = "Google Translate to serve as a command-line tool"
-    Version     = "0.9.0.3"
+    Version     = "0.9.0.4"
     ReleaseDate = "2015-05-26"
     Command     = "trans"
     EntryPoint  = "translate.awk"


### PR DESCRIPTION
Self-upgrading might be a misfeature for translate-shell, as it could mess up with the information kept by the package manager. The `-upgrade` option now still checks for upgrade and gives hint if a new version is available, but will never upgrade the program. Upgrading is left to users to perform (by downloading, brew, git pull, etc.)
