### PR TITLE
0.9.1 Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ check: test
 	[ "`$(BUILDDIR)/$(COMMAND) -b 忍者`" = 'Ninja' ]
 
 install:
-	@install $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\
+	@install -D $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\
 	mkdir -p $(PREFIX)/share/man/man1 &&\
 	cp $(MANDIR)/$(COMMAND).1 $(PREFIX)/share/man/man1/$(COMMAND).1 &&\
 	echo "[OK] $(NAME) installed."

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -99,6 +99,8 @@ function getHelp() {
         RS "Audio options:" RS                                          \
         ins(1, ansi("bold", "-p, -play")) RS                            \
         ins(2, "Listen to the translation.") RS                         \
+        ins(1, ansi("bold", "-speak")) RS                               \
+        ins(2, "Listen to the original text.") RS                       \
         ins(1, ansi("bold", "-player ") ansi("underline", "PROGRAM")) RS \
         ins(2, "Specify the audio player to use, and listen to the translation.") RS \
         ins(1, ansi("bold", "-no-play")) RS                             \

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -67,6 +67,8 @@ function getHelp() {
         ins(2, "Brief mode.") RS                                        \
         ins(1, ansi("bold", "-d") ", " ansi("bold", "-dictionary")) RS  \
         ins(2, "Dictionary mode.") RS                                   \
+        ins(1, ansi("bold", "-identify")) RS                            \
+        ins(2, "Language identification.") RS                           \
         ins(1, ansi("bold", "-show-original ") ansi("underline", "Y/n")) RS \
         ins(2, "Show original text or not.") RS                         \
         ins(1, ansi("bold", "-show-original-phonetics ") ansi("underline", "Y/n")) RS \

--- a/include/Languages.awk
+++ b/include/Languages.awk
@@ -1699,6 +1699,10 @@ function initLocale(    i) {
 
         # ISO 639-3 codes as aliases
         LocaleAlias[Locale[i]["iso"]] = i
+
+        # Names and endonyms as aliases
+        LocaleAlias[tolower(Locale[i]["name"])] = i
+        LocaleAlias[tolower(Locale[i]["endonym"])] = i
     }
 
     # Other aliases
@@ -1713,6 +1717,7 @@ function initLocale(    i) {
     LocaleAlias["sh"] = "sr" # Serbo-Croatian: default to Serbian
     LocaleAlias["zh"] = "zh-CN" # Chinese: default to Chinese Simplified
     LocaleAlias["zho"] = "zh-CN"
+    LocaleAlias["chinese"] = "zh-CN"
     # TODO: more aliases
 }
 
@@ -1722,6 +1727,8 @@ function getCode(code) {
         return code
     else if (code in LocaleAlias)
         return LocaleAlias[code]
+    else if (tolower(code) in LocaleAlias)
+        return LocaleAlias[tolower(code)]
     else
         return # return nothing if not found
 }

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -246,6 +246,13 @@ BEGIN {
             continue
         }
 
+        # -identify
+        match(ARGV[pos], /^--?id(e(n(t(i(fy?)?)?)?)?)?$/)
+        if (RSTART) {
+            Option["verbose"] = -1
+            continue
+        }
+
         # -show-original Y/n
         match(ARGV[pos], /^--?show-original(=(.*)?)?$/, group)
         if (RSTART) {

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -367,7 +367,7 @@ BEGIN {
         }
 
         # -speak
-        match(ARGV[pos], /^--?speak$/)
+        match(ARGV[pos], /^--?sp(e(ak?)?)?$/)
         if (RSTART) {
             Option["play"] = 2
             continue

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -359,10 +359,17 @@ BEGIN {
             continue
         }
 
+        # -speak
+        match(ARGV[pos], /^--?speak$/)
+        if (RSTART) {
+            Option["play"] = 2
+            continue
+        }
+
         # -player PROGRAM
         match(ARGV[pos], /^--?player(=(.*)?)?$/, group)
         if (RSTART) {
-            Option["play"] = 1
+            if (!Option["play"]) Option["play"] = 1 # -play by default
             Option["player"] = group[1] ?
                 (group[2] ? group[2] : Option["player"]) :
                 ARGV[++pos]

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -216,6 +216,8 @@ function getTranslation(text, sl, tl, hl,
     translation = join(translations)
 
     returnIl[0] = il = !anything(ils) || belongsTo(sl, ils) ? sl : ils[0]
+    if (Option["verbose"] < 0)
+        return getList(il)
 
     # Generate output
     if (!isVerbose) {

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -101,7 +101,7 @@ function play(text, tl,    url) {
 
 # Get the translation of a string.
 function getTranslation(text, sl, tl, hl,
-                        isVerbose, toSpeech, returnPlaylist,
+                        isVerbose, toSpeech, returnPlaylist, returnIl,
                         ####
                         r,
                         content, tokens, ast,
@@ -215,7 +215,7 @@ function getTranslation(text, sl, tl, hl,
 
     translation = join(translations)
 
-    il = !anything(ils) || belongsTo(sl, ils) ? sl : ils[0]
+    returnIl[0] = il = !anything(ils) || belongsTo(sl, ils) ? sl : ils[0]
 
     # Generate output
     if (!isVerbose) {
@@ -497,7 +497,7 @@ function webTranslation(uri, sl, tl, hl) {
 # Translate the source text (into all target languages).
 function translate(text, inline,
                    ####
-                   i, j, playlist, saveSortedIn) {
+                   i, j, playlist, il, saveSortedIn) {
 
     if (!getCode(Option["hl"])) {
         # Check if home language is supported
@@ -536,15 +536,21 @@ function translate(text, inline,
             # translate URL only from command-line parameters (inline)
             webTranslation(text, Option["sl"], Option["tl"][i], Option["hl"])
         } else {
-            p(getTranslation(text, Option["sl"], Option["tl"][i], Option["hl"], Option["verbose"], Option["play"], playlist))
+            p(getTranslation(text, Option["sl"], Option["tl"][i], Option["hl"], Option["verbose"], Option["play"], playlist, il))
 
-            if (Option["play"])
+            if (Option["play"] == 1) {
                 if (Option["player"])
                     for (j in playlist)
                         play(playlist[j]["text"], playlist[j]["tl"])
                 else if (SpeechSynthesizer)
                     for (j in playlist)
                         print playlist[j]["text"] | SpeechSynthesizer
+            } else if (Option["play"] == 2) {
+                if (Option["player"])
+                    play(text, il[0])
+                else if (SpeechSynthesizer)
+                    print text | SpeechSynthesizer
+            }
         }
     }
     PROCINFO["sorted_in"] = saveSortedIn

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -563,16 +563,22 @@ function translateMain(    i, line) {
     if (Option["interactive"])
         prompt()
 
-    i = 0
-    while (getline line < Option["input"]) {
-        # Non-interactive verbose mode: separator between sources
-        if (!Option["interactive"])
-            if (Option["verbose"] && i++ > 0)
-                p(prettify("source-seperator", replicate(Option["chr-source-seperator"], Option["width"])))
+    if (Option["input"] == STDIN || fileExists(Option["input"])) {
+        i = 0
+        while (getline line < Option["input"])
+            if (line) {
+                # Non-interactive verbose mode: separator between sources
+                if (!Option["interactive"])
+                    if (Option["verbose"] && i++ > 0)
+                        p(prettify("source-seperator",
+                                   replicate(Option["chr-source-seperator"],
+                                             Option["width"])))
 
-        if (Option["interactive"])
-            repl(line)
-        else
-            translate(line)
-    }
+                if (Option["interactive"])
+                    repl(line)
+                else
+                    translate(line)
+            }
+    } else
+        e("[ERROR] File not found: " Option["input"])
 }

--- a/man/trans.1
+++ b/man/trans.1
@@ -1,4 +1,4 @@
-.TH "TRANS" "1" "2015\-10\-05" "0.9.0.9" ""
+.TH "TRANS" "1" "2015\-11\-08" "0.9.1" ""
 .SH NAME
 .PP
 trans \- Google Translate served as a command\-line tool
@@ -84,6 +84,13 @@ Dictionary mode.
 .RS
 .PP
 Show the definition of the original word in the dictionary.
+.RE
+.TP
+.B \f[B]\-identify\f[]
+Language identification.
+.RS
+.PP
+Show the identified language of the original text.
 .RE
 .TP
 .B \f[B]\-show\-original\f[] \f[I]Y/n\f[]
@@ -182,6 +189,11 @@ You must have at least one of the supported audio players
 from Google Text\-to\-Speech engine.
 Otherwise, a local speech synthesizer may be used instead (\f[B]say\f[]
 on Mac OS X, \f[B]espeak\f[] on Linux or other platforms).
+.RE
+.TP
+.B \f[B]\-speak\f[]
+Listen to the original text.
+.RS
 .RE
 .TP
 .B \f[B]\-player\f[] \f[I]PROGRAM\f[]

--- a/man/trans.1.md
+++ b/man/trans.1.md
@@ -1,6 +1,6 @@
-% TRANS(1) 0.9.0.9
+% TRANS(1) 0.9.1
 % Mort Yao <soi@mort.ninja>
-% 2015-10-05
+% 2015-11-08
 
 # NAME
 
@@ -62,6 +62,11 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 
     Show the definition of the original word in the dictionary.
 
+**-identify**
+:   Language identification.
+
+    Show the identified language of the original text.
+
 **-show-original** *Y/n*
 :   Show original text or not. (default: yes)
 
@@ -114,6 +119,9 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 :   Listen to the translation.
 
     You must have at least one of the supported audio players (**mplayer**, **mpv** or **mpg123**) installed to stream from Google Text-to-Speech engine. Otherwise, a local speech synthesizer may be used instead (**say** on Mac OS X, **espeak** on Linux or other platforms).
+
+**-speak**
+:   Listen to the original text.
 
 **-player** *PROGRAM*
 :   Specify the audio player to use, and listen to the translation.

--- a/man/trans.1.template.md
+++ b/man/trans.1.template.md
@@ -62,6 +62,11 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 
     Show the definition of the original word in the dictionary.
 
+**-identify**
+:   Language identification.
+
+    Show the identified language of the original text.
+
 **-show-original** *Y/n*
 :   Show original text or not. (default: yes)
 
@@ -114,6 +119,9 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 :   Listen to the translation.
 
     You must have at least one of the supported audio players (**mplayer**, **mpv** or **mpg123**) installed to stream from Google Text-to-Speech engine. Otherwise, a local speech synthesizer may be used instead (**say** on Mac OS X, **espeak** on Linux or other platforms).
+
+**-speak**
+:   Listen to the original text.
 
 **-player** *PROGRAM*
 :   Specify the audio player to use, and listen to the translation.

--- a/metainfo.awk
+++ b/metainfo.awk
@@ -1,8 +1,8 @@
 BEGIN {
     Name        = "Translate Shell"
     Description = "Google Translate to serve as a command-line tool"
-    Version     = "0.9.1-dev"
-    ReleaseDate = "2015-10-05"
+    Version     = "0.9.1"
+    ReleaseDate = "2015-11-08"
     Command     = "trans"
     EntryPoint  = "translate.awk"
 }


### PR DESCRIPTION
### New option: `-speak`

It makes sense when you're only interested in **how a word is exactly pronounced in some language**, but not their translations.

```
$ trans -sp København Köpenhamn Kopenhagen Copenhagen
```

It's possible to specify a language, in case auto-detection fails:

```
$ trans -sp zh: 中国
$ trans -sp ja: 中国
```
### New option: `-identify`

Use Google Translate for language identification. 

```
$ trans -id København Köpenhamn Kopenhagen
```
### Use language names as alternatives to ISO codes

You may use them with the `-t` and `-s` options.

```
$ trans -t Chinese mushroom
$ trans -t dansk presence
$ trans -t 日本語 moon
```
### Notice: removed languages

It turns out that some languages previously available via the Google Translate API have been removed now (as Google Translate might want to polish their support for those before revealing to the public), including Tibetan, Dzongkha, Uyghur, Hawaiian, etc. Hopefully there will be brought back in the future so I'll keep them there.
