### PR TITLE
Calculate that freaking tk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: build
 
 check: test
 	$(BUILDDIR)/$(COMMAND) -V
-	[ "`$(BUILDDIR)/$(COMMAND) -b 忍者`" = 'Ninja' ]
+	[ "`$(BUILDDIR)/$(COMMAND) -no-init -b 忍者`" = 'Ninja' ]
 
 install:
 	@install -D $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: build
 
 check: test
 	$(BUILDDIR)/$(COMMAND) -V
-	[ "`$(BUILDDIR)/$(COMMAND) -no-init -b 忍者`" = 'Ninja' ]
+	[ "`$(BUILDDIR)/$(COMMAND) -no-init -D -b 忍者`" = 'Ninja' ]
 
 install:
 	@install -D $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\

--- a/include/GenTK.awk
+++ b/include/GenTK.awk
@@ -1,0 +1,39 @@
+####################################################################
+# GenTK.awk                                                        #
+####################################################################
+#
+# Last Updated: 18 Dec 2015
+# https://translate.google.com/translate/releases/twsfe_w_20151214_RC03/r/js/desktop_module_main.js
+
+function genRL(a, x,
+               ####
+               b, c, d, i, y) {
+    tokenize(y, x)
+    parseList(b, y)
+    i = SUBSEP 0
+    for (c = 0; c < length(b[i]) - 2; c += 3) {
+        d = b[i][c + 2]
+        d = d >= 97 ? d - 87 :
+            d - 48 # convert to number
+        d = b[i][c + 1] == 43 ? rshift(a, d) : lshift(a, d)
+        a = b[i][c] == 43 ? and(a + d, 4294967295) : xor(a, d)
+    }
+    return a
+}
+
+function genTK(text,
+               ####
+               a, d, dLen, e, tkk, ub, vb) {
+    tkk = systime() / 3600
+    ub = "[43,45,51,94,43,98,43,45,102]"
+    vb = "[43,45,97,94,43,54]"
+
+    dLen = dump(text, d) # convert to byte array
+    a = tkk
+    for (e = 1; e <= dLen; e++)
+        a = genRL(a + d[e], vb)
+    a = genRL(a, ub)
+    0 > a && (a = and(a, 2147483647) + 2147483648)
+    a %= 1e6
+    return a "." xor(a, tkk)
+}

--- a/include/GenTK.awk
+++ b/include/GenTK.awk
@@ -24,6 +24,8 @@ function genRL(a, x,
 function genTK(text,
                ####
                a, d, dLen, e, tkk, ub, vb) {
+    if (TK[text]) return TK[text]
+
     tkk = systime() / 3600
     ub = "[43,45,51,94,43,98,43,45,102]"
     vb = "[43,45,97,94,43,54]"
@@ -35,5 +37,5 @@ function genTK(text,
     a = genRL(a, ub)
     0 > a && (a = and(a, 2147483647) + 2147483648)
     a %= 1e6
-    return a "." xor(a, tkk)
+    return TK[text] = a "." xor(a, tkk)
 }

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -65,7 +65,8 @@ function getResponse(text, sl, tl, hl,    content, header, url) {
     url = HttpPathPrefix "/translate_a/single?client=t"                 \
         "&ie=UTF-8&oe=UTF-8"                                            \
         "&dt=bd&dt=ex&dt=ld&dt=md&dt=qca&dt=rw&dt=rm&dt=ss&dt=t&dt=at"  \
-        "&q=" preprocess(text) "&sl=" sl "&tl=" tl "&hl=" hl "&tk"
+        "&sl=" sl "&tl=" tl "&hl=" hl                                   \
+        "&tk=" genTK(text) "&q=" preprocess(text)
     header = "GET " url " HTTP/1.1\n"           \
         "Host: " HttpHost "\n"                  \
         "Connection: close\n"
@@ -93,7 +94,7 @@ function p(string) {
 # Play using Google Text-to-Speech engine.
 function play(text, tl,    url) {
     url = HttpProtocol HttpHost "/translate_tts?ie=UTF-8&client=t"	\
-        "&tl=" tl "&tk" "&q=" preprocess(text)
+        "&tl=" tl "&tk=" genTK(text) "&q=" preprocess(text)
 
     # Don't use getline from pipe here - the same pipe will be run only once for each AWK script!
     system(Option["player"] " " parameterize(url) SUPOUT SUPERR)

--- a/include/Utils.awk
+++ b/include/Utils.awk
@@ -157,7 +157,7 @@ function curl(url,    command, content, line) {
 # Dump a Unicode string into a byte array. Return the length of the array.
 # NOTE: can only be ran once for each text! Build a cache.
 function dump(text, group,    command, temp) {
-    command = "hexdump" " -e'1/1 \"%03d\" \" \"'"
+    command = "hexdump" " -e'1/1 \"%03u\" \" \"'"
     ("echo " parameterize(text) PIPE command) | getline temp
     split(temp, group, " ")
     return length(group) - 1

--- a/include/Utils.awk
+++ b/include/Utils.awk
@@ -155,6 +155,7 @@ function curl(url,    command, content, line) {
 }
 
 # Dump a Unicode string into a byte array. Return the length of the array.
+# NOTE: can only be ran once for each text! Build a cache.
 function dump(text, group,    command, temp) {
     command = "hexdump" " -e'1/1 \"%03d\" \" \"'"
     ("echo " parameterize(text) PIPE command) | getline temp

--- a/include/Utils.awk
+++ b/include/Utils.awk
@@ -153,3 +153,11 @@ function curl(url,    command, content, line) {
         return content
     }
 }
+
+# Dump a Unicode string into a byte array. Return the length of the array.
+function dump(text, group,    command, temp) {
+    command = "hexdump" " -e'1/1 \"%03d\" \" \"'"
+    ("echo " parameterize(text) PIPE command) | getline temp
+    split(temp, group, " ")
+    return length(group) - 1
+}

--- a/test/TestUtils.awk
+++ b/test/TestUtils.awk
@@ -30,5 +30,17 @@ BEGIN {
         assertTrue(newerVersion("2", "1.9.9999"))
     }
 
+    T("dump()", 3)
+    {
+        delete group
+        assertEqual(dump("a", group), 1)
+
+        delete group
+        assertEqual(dump("Århus", group), 6)
+
+        delete group
+        assertEqual(dump("안녕하세요 세계", group), 22)
+    }
+
     END_TEST()
 }

--- a/translate.awk
+++ b/translate.awk
@@ -5,6 +5,8 @@
 @include "include/Commons"
 @include "include/Utils"
 
+@include "include/GenTK"
+
 @include "include/Languages"
 @include "include/Help"
 @include "include/Parser"


### PR DESCRIPTION
... And fix #94.

Note that this is not a "pure AWK" solution - it relies on the Unix `hexdump` utility to convert a UTF-8 string to a byte array (since there's no way you can do that in GNU Awk without recreating the wheel in bare metal).

Should have written `trans` in Perl, or Python, Node.js or whatever language sounds sane. Now I feel I'm so 1970s :neckbeard:, having to pipe things altogether to another Unix process for very basic string decoding.
