### PR TITLE
Install trans as a Zsh plugin

### DIFF
--- a/translate-shell.plugin.zsh
+++ b/translate-shell.plugin.zsh
@@ -1,0 +1,2 @@
+#!/usr/bin/env zsh
+alias trans="$(dirname $0)/translate"


### PR DESCRIPTION
I've added a file `translate-shell.plugin.zsh` to the repository, so that now it's possible to install `trans` as a Zsh plugin (via the bundle manager [Antigen](https://github.com/zsh-users/antigen)).

Add the following line to your `.zshrc`:

```
antigen bundle soimort/translate-shell
```
