### PR TITLE
make install: depend on `build` and fix on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ check: test
 	[ "`$(BUILDDIR)/$(COMMAND) -no-init -D -b 'hello world'`" = 'hello world' ]
 
 install: build
-	@install -D $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\
+	@mkdir -p $(PREFIX)/bin &&\
+	install $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\
 	mkdir -p $(PREFIX)/share/man/man1 &&\
 	cp $(MANDIR)/$(COMMAND).1 $(PREFIX)/share/man/man1/$(COMMAND).1 &&\
 	echo "[OK] $(NAME) installed."

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ check: test
 	[ "`$(BUILDDIR)/$(COMMAND) -no-init -D -b 忍者`" = 'Ninja' ] &&\
 	[ "`$(BUILDDIR)/$(COMMAND) -no-init -D -b 'hello world'`" = 'hello world' ]
 
-install:
+install: build
 	@install -D $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\
 	mkdir -p $(PREFIX)/share/man/man1 &&\
 	cp $(MANDIR)/$(COMMAND).1 $(PREFIX)/share/man/man1/$(COMMAND).1 &&\


### PR DESCRIPTION
The `-D` flag isn't available on OSX's `install`.
