### PR TITLE
Autocorrection and spell checking

### DIFF
--- a/include/Help.awk
+++ b/include/Help.awk
@@ -105,6 +105,8 @@ function getHelp() {
         ins(2, "Do not use any other theme than default.") RS           \
         ins(1, ansi("bold", "-no-ansi")) RS                             \
         ins(2, "Do not use ANSI escape codes.") RS                      \
+        ins(1, ansi("bold", "-no-autocorrect")) RS                      \
+        ins(2, "Do not autocorrect. (if defaulted by the translation engine)") RS \
         ins(1, ansi("bold", "-no-bidi")) RS                             \
         ins(2, "Do not convert bidirectional texts.") RS                \
         RS "Audio options:" RS                                          \

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -34,6 +34,7 @@ function init() {
     Option["width"] = ENVIRON["COLUMNS"] ? ENVIRON["COLUMNS"] - 2 : 0
     Option["indent"] = 4
     Option["no-ansi"] = 0
+    Option["no-autocorrect"] = 0
     Option["no-bidi"] = 0
     Option["theme"] = "default"
 
@@ -393,6 +394,13 @@ BEGIN {
         match(ARGV[pos], /^--?no-ansi$/)
         if (RSTART) {
             Option["no-ansi"] = 1
+            continue
+        }
+
+        # -no-autocorrect
+        match(ARGV[pos], /^--?no-auto(correct)?$/)
+        if (RSTART) {
+            Option["no-autocorrect"] = 1
             continue
         }
 

--- a/include/Translators/GoogleTranslate.awk
+++ b/include/Translators/GoogleTranslate.awk
@@ -52,11 +52,12 @@ function googleInit() {
     HttpPort = 80
 }
 
-function googleRequestUrl(text, sl, tl, hl) {
+function googleRequestUrl(text, sl, tl, hl,    qc) {
+    qc = Option["no-autocorrect"] ? "qc" : "qca";
     return HttpPathPrefix "/translate_a/single?client=gtx"              \
         "&ie=UTF-8&oe=UTF-8"                                            \
-        "&dt=bd&dt=ex&dt=ld&dt=md&dt=qca&dt=rw&dt=rm&dt=ss&dt=t&dt=at"  \
-        "&sl=" sl "&tl=" tl "&hl=" hl                                   \
+        "&dt=bd&dt=ex&dt=ld&dt=md&dt=rw&dt=rm&dt=ss&dt=t&dt=at"         \
+        "&dt=" qc "&sl=" sl "&tl=" tl "&hl=" hl                         \
         "&q=" preprocess(text)
 }
 
@@ -147,6 +148,10 @@ function googleTranslate(text, sl, tl, hl,
         }
         if (match(i, "^0" SUBSEP "5" SUBSEP "([[:digit:]]+)" SUBSEP "2" SUBSEP "([[:digit:]]+)" SUBSEP "0$", group))
             altTranslations[group[1]][group[2]] = postprocess(literal(ast[i]))
+
+        # 7 - autocorrection
+        if (i ~ "^0" SUBSEP "7" SUBSEP "5$")
+            w("Showing translation for:  (use -no-auto to disable autocorrect)")
 
         # 8 - identified source languages
         if (i ~ "^0" SUBSEP "8" SUBSEP "0" SUBSEP "[[:digit:]]+$" ||


### PR DESCRIPTION
Google Translate performs autocorrection on some words, that is not always desirable and sometimes prevents users from translating the wanted word (e.g. _tumbler_).

Now `trans` will give a warning if autocorrect has been applied, and you may specify the **`-no-auto`** option to disable that autocorrection. (i.e., to translate the word as it is)

![screenshot from 2016-07-20 08-20-14](https://cloud.githubusercontent.com/assets/342945/16977626/90397db2-4e57-11e6-9bc9-1b2b1df738ae.png)

With that warning, `trans` may be used as a simple CLI spellchecker: (when you're not sure if you spelled a tricky word right, the warning tells you)

![screenshot from 2016-07-20 08-21-01](https://cloud.githubusercontent.com/assets/342945/16977801/97ca38e0-4e58-11e6-969a-22570fef1116.png)

![screenshot from 2016-07-20 08-21-01_](https://cloud.githubusercontent.com/assets/342945/16977803/9b882fb4-4e58-11e6-9233-631fa362366c.png)

(Currently this feature is available for only the Google Translate engine.)
