### PR TITLE
Fix TTS support for Bing Translator

### DIFF
--- a/include/Main.awk
+++ b/include/Main.awk
@@ -40,7 +40,7 @@ function init() {
 
     # Audio
     Option["play"] = 0
-    Option["narrator"] = "default"
+    Option["narrator"] = "female"
     Option["player"] = ENVIRON["PLAYER"]
 
     # Terminal paging and browsing


### PR DESCRIPTION
Specify the narrator using the `-n` option. `-n f` for female's voice, `-n m` for male's voice:

```sh
$ trans -e bing "Why not test this thing" :yue -p -n f
```

```sh
$ trans -e bing "Why not test this thing" :yue -p -n m
```

2-letter (uppercase) country code may also be used when applicable, e.g., for Indian English:

```sh
$ trans -e bing "Why not test this thing" -sp -n IN
```

Reference:

| Target language | Supported variants |
| -- | -- |
| `en` | `US`, `GB` (UK), `IN` (India), `AU` (Australia), `CA` (Canada) |
| `es` | `ES`, `MX` (Mexico) |
| `pt` | `PT`, `BR` (Brazil) |
| `fr` | `FR`, `CA` (Canada) |
| `zh` | `CN`, `TW` (Taiwan), `HK` (Hong Kong) |

Gender and country code may be combined with a comma `,`

```sh
$ trans -e bing "Why not test this thing" -sp -n US,m
```
