### PR TITLE
Spell checking via trans

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -80,6 +80,8 @@ These dependencies are optional, but strongly recommended for full functionality
     * required for terminal paging
 * **[rlwrap](http://utopia.knoware.nl/~hlub/uck/rlwrap/#rlwrap)**: *a GNU readline wrapper*
     * required for readline-style editing and history in the interactive shell
+* **[aspell](http://aspell.net/)** or **[hunspell](http://hunspell.github.io/)**
+    * required for spell checking
 
 ### Environment and Fonts
 

--- a/include/Translators/*.awk
+++ b/include/Translators/*.awk
@@ -2,3 +2,4 @@
 @include "include/Translators/BingTranslator.awk"
 @include "include/Translators/YandexTranslate.awk"
 @include "include/Translators/Apertium.awk"
+@include "include/Translators/SpellChecker.awk"

--- a/include/Translators/SpellChecker.awk
+++ b/include/Translators/SpellChecker.awk
@@ -1,0 +1,51 @@
+####################################################################
+# SpellChecker.awk                                                 #
+####################################################################
+BEGIN { provides("spell") }
+
+# Detect external spell checker.
+function spellInit() {
+    Ispell = detectProgram("aspell", "--version") ? "aspell" :
+        (detectProgram("hunspell", "--version") ? "hunspell" : "")
+
+    if (!Ispell) {
+        e("[ERROR] Spell checker (aspell or hunspell) not found.")
+        exit 1
+    }
+}
+
+# Check a string.
+function spellTranslate(text, sl, tl, hl,
+                        isVerbose, toSpeech, returnPlaylist, returnIl,
+                        ####
+                        args, i, j, r, line, group, word, sug) {
+    args = " -a" (sl != "auto" ? " -d " sl : "")
+    if (system("echo" PIPE Ispell args SUPOUT SUPERR)) {
+        e("[ERROR] No dictionary for language: " sl)
+        exit 1
+    }
+
+    i = 1
+    r = ""
+    while ((("echo " parameterize(text) PIPE Ispell args SUPERR) |& getline line) > 0) {
+        match(line,
+              /^& (.*) [[:digit:]]+ [[:digit:]]+: ([^,]+)(, ([^,]+))?(, ([^,]+))?/,
+              group)
+        if (RSTART) {
+            ExitCode = 1 # found a spelling error
+
+            word = group[1]
+            sug = "[" group[2]
+            if (group[4]) sug = sug "|" group[4]
+            if (group[6]) sug = sug "|" group[6]
+            sug = sug "]"
+
+            j = i + index(substr(text, i), word) - 1
+            r = r substr(text, i, j - i)
+            r = r ansi("bold", ansi("red", word)) ansi("yellow", sug)
+            i = j + length(word)
+        }
+    }
+    r = r substr(text, i)
+    return r
+}

--- a/include/Translators/SpellChecker.awk
+++ b/include/Translators/SpellChecker.awk
@@ -1,15 +1,33 @@
 ####################################################################
 # SpellChecker.awk                                                 #
 ####################################################################
-BEGIN { provides("spell") }
+BEGIN {
+    provides("spell")
+    provides("aspell")
+    provides("hunspell")
+}
 
-# Detect external spell checker.
+# Detect external (ispell -a compatible) spell checker.
 function spellInit() {
     Ispell = detectProgram("aspell", "--version") ? "aspell" :
         (detectProgram("hunspell", "--version") ? "hunspell" : "")
 
     if (!Ispell) {
         e("[ERROR] Spell checker (aspell or hunspell) not found.")
+        exit 1
+    }
+}
+
+function aspellInit() {
+    if (!(Ispell = detectProgram("aspell", "--version") ? "aspell" : "")) {
+        e("[ERROR] Spell checker (aspell) not found.")
+        exit 1
+    }
+}
+
+function hunspellInit() {
+    if (!(Ispell = detectProgram("hunspell", "--version") ? "hunspell" : "")) {
+        e("[ERROR] Spell checker (hunspell) not found.")
         exit 1
     }
 }
@@ -48,4 +66,14 @@ function spellTranslate(text, sl, tl, hl,
     }
     r = r substr(text, i)
     return r
+}
+
+function aspellTranslate(text, sl, tl, hl,
+                         isVerbose, toSpeech, returnPlaylist, returnIl) {
+    return spellTranslate(text, sl, tl, hl)
+}
+
+function hunspellTranslate(text, sl, tl, hl,
+                           isVerbose, toSpeech, returnPlaylist, returnIl) {
+    return spellTranslate(text, sl, tl, hl)
 }


### PR DESCRIPTION
A simple wrapper for spell checking utilities GNU Aspell and Hunspell (but allows you to input words / sentences in the same way that `trans` does, instead of using the traditional Ispell -a interface). 

Use one of these engines:
- `aspell`
- `hunspell`
- `spell` (use an available spell checker automatically)

Examples:

```
$ trans -e spell 'There is a mispelling in this sentence!'
# Or:
$ trans /sp 'There is a mispelling in this sentence!'

$ trans -e aspell begining

$ trans -e hunspell commitee
```

It is also possible to specify a (non-English) source language for spell checking. Notice that the code name must match the *dictionary name* that is actually installed in the system (thus it might differ from its official ISO 639 code), e.g.,

```
$ trans /sp -s en_GB colour
$ trans /sp -s fr_FR colleur
```