### PR TITLE
Implement more complete install usage and DESTDIR support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ check: test
 	[ "`$(BUILDDIR)/$(COMMAND) -no-init -D -b 'hello world'`" = 'hello world' ]
 
 install: build
-	@mkdir -p $(PREFIX)/bin &&\
-	install $(BUILDDIR)/$(COMMAND) $(PREFIX)/bin/$(COMMAND) &&\
-	mkdir -p $(PREFIX)/share/man/man1 &&\
-	install $(MANDIR)/$(COMMAND).1 $(PREFIX)/share/man/man1/$(COMMAND).1 &&\
+	@mkdir -p $(DESTDIR)$(PREFIX)/bin &&\
+	install $(BUILDDIR)/$(COMMAND) $(DESTDIR)$(PREFIX)/bin/$(COMMAND) &&\
+	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1 &&\
+	install $(MANDIR)/$(COMMAND).1 $(DESTDIR)$(PREFIX)/share/man/man1/$(COMMAND).1 &&\
 	echo "[OK] $(NAME) installed."
 
 uninstall:
-	@rm $(PREFIX)/bin/$(COMMAND) $(PREFIX)/share/man/man1/$(COMMAND).1 &&\
+	@rm $(DESTDIR)$(PREFIX)/bin/$(COMMAND) $(DESTDIR)$(PREFIX)/share/man/man1/$(COMMAND).1 &&\
 	echo "[OK] $(NAME) uninstalled."


### PR DESCRIPTION
[DESTDIR](https://www.gnu.org/prep/standards/html_node/DESTDIR.html), or destination directory, is used by build environments / systems like [solbuild](https://github.com/solus-project/solbuild) and via [macros such as %make_install](https://github.com/solus-project/ypkg/blob/master/ypkg2/rc.yml#L13) to provide an alternative install root, where the contents of such install root are then bundled up into binary packages for installation onto the user's system or being placed into a repository.

By default, DESTDIR is not defined, and thus does not change any behavior already established in translate-shell's Makefile. I have however built upon the work from dec3d1bfaef9f4ac158a1096cb98d5665b2da645 to ensure that the appropriate permissions are set during an install call (as opposed to mkdir) and simplies binary installation as the binary directory and executable are the same permissions.