### PR TITLE
New options: -dump and -download-audio(-as)

### DIFF
--- a/include/Help.awk
+++ b/include/Help.awk
@@ -109,6 +109,8 @@ function getHelp() {
         ins(2, "Do not autocorrect. (if defaulted by the translation engine)") RS \
         ins(1, ansi("bold", "-no-bidi")) RS                             \
         ins(2, "Do not convert bidirectional texts.") RS                \
+        ins(1, ansi("bold", "-dump")) RS                                \
+        ins(2, "Print raw API response instead.") RS                    \
         RS "Audio options:" RS                                          \
         ins(1, ansi("bold", "-p, -play")) RS                            \
         ins(2, "Listen to the translation.") RS                         \

--- a/include/Help.awk
+++ b/include/Help.awk
@@ -125,6 +125,10 @@ function getHelp() {
         ins(2, "Do not listen to the translation.") RS                  \
         ins(1, ansi("bold", "-no-translate")) RS                        \
         ins(2, "Do not translate anything when using -speak.") RS       \
+        ins(1, ansi("bold", "-download-audio")) RS                      \
+        ins(2, "Download the audio to the current directory.") RS       \
+        ins(1, ansi("bold", "-download-audio-as ") ansi("underline", "FILENAME")) RS \
+        ins(2, "Download the audio to the specified file.") RS          \
         RS "Terminal paging and browsing options:" RS                   \
         ins(1, ansi("bold", "-v") ", " ansi("bold", "-view")) RS        \
         ins(2, "View the translation in a terminal pager.") RS          \

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -44,6 +44,8 @@ function init() {
     Option["narrator"] = "female"
     Option["player"] = ENVIRON["PLAYER"]
     Option["no-translate"] = 0
+    Option["download-audio"] = 0
+    Option["download-audio-as"] = NULLSTR
 
     # Terminal paging and browsing
     Option["view"] = 0
@@ -470,6 +472,23 @@ BEGIN {
         match(ARGV[pos], /^--?no-tran(s(l(a(te?)?)?)?)?$/)
         if (RSTART) {
             Option["no-translate"] = 1
+            continue
+        }
+
+        # -download-audio
+        match(ARGV[pos], /^--?download-a(u(d(io?)?)?)?$/)
+        if (RSTART) {
+            Option["download-audio"] = 1
+            continue
+        }
+
+        # -download-audio-as
+        match(ARGV[pos], /^--?download-audio-as(=(.*)?)?$/, group)
+        if (RSTART) {
+            if (!Option["download-audio"]) Option["download-audio"] = 1
+            Option["download-audio-as"] = group[1] ?
+                (group[2] ? group[2] : Option["download-audio-as"]) :
+                ARGV[++pos]
             continue
         }
 

--- a/include/Main.awk
+++ b/include/Main.awk
@@ -37,6 +37,7 @@ function init() {
     Option["no-autocorrect"] = 0
     Option["no-bidi"] = 0
     Option["theme"] = "default"
+    Option["dump"] = 0
 
     # Audio
     Option["play"] = 0
@@ -412,6 +413,13 @@ BEGIN {
         match(ARGV[pos], /^--?no-bidi/)
         if (RSTART) {
             Option["no-bidi"] = 1
+            continue
+        }
+
+        # -dump
+        match(ARGV[pos], /^--?dump/)
+        if (RSTART) {
+            Option["dump"] = 1
             continue
         }
 

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -144,6 +144,18 @@ function play(text, tl,    url) {
     system(Option["player"] " " parameterize(url) SUPOUT SUPERR)
 }
 
+# Download audio from a Text-to-Speech engine.
+function download_audio(text, tl,    url, output) {
+    url = _TTSUrl(text, tl)
+
+    if (Option["download-audio-as"])
+        curl(url, Option["download-audio-as"])
+    else {
+        output = text " [" Option["engine"] "] (" Option["narrator"] ").ts"
+        curl(url, output)
+    }
+}
+
 # Get the translation of a string.
 function getTranslation(text, sl, tl, hl,
                         isVerbose, toSpeech, returnPlaylist, returnIl) {
@@ -220,16 +232,20 @@ function translate(text, inline,
                 il[0] = Option["sl"] == "auto" ? "en" : Option["sl"]
 
             if (Option["play"] == 1) {
-                if (Option["player"])
+                if (Option["player"]) {
                     for (j in playlist)
                         play(playlist[j]["text"], playlist[j]["tl"])
-                else if (SpeechSynthesizer)
+                    if (Option["download-audio"])
+                        download_audio(playlist[length(playlist) - 1]["text"], playlist[length(playlist) - 1]["tl"])
+                } else if (SpeechSynthesizer)
                     for (j in playlist)
                         print playlist[j]["text"] | SpeechSynthesizer
             } else if (Option["play"] == 2) {
-                if (Option["player"])
+                if (Option["player"]) {
                     play(text, il[0])
-                else if (SpeechSynthesizer)
+                    if (Option["download-audio"])
+                        download_audio(text, il[0])
+                } else if (SpeechSynthesizer)
                     print text | SpeechSynthesizer
             }
         }

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -149,11 +149,14 @@ function download_audio(text, tl,    url, output) {
     url = _TTSUrl(text, tl)
 
     if (Option["download-audio-as"])
-        curl(url, Option["download-audio-as"])
-    else {
+        output = Option["download-audio-as"]
+    else
         output = text " [" Option["engine"] "] (" Option["narrator"] ").ts"
+
+    if (url ~ /^\//)
+        system("mv -- " parameterize(url) " " parameterize(output))
+    else
         curl(url, output)
-    }
 }
 
 # Get the translation of a string.

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -227,26 +227,31 @@ function translate(text, inline,
             webTranslation(text, Option["sl"], Option["tl"][i], Option["hl"])
         } else {
             if (!Option["no-translate"])
-                p(getTranslation(text, Option["sl"], Option["tl"][i], Option["hl"], Option["verbose"], Option["play"], playlist, il))
+                p(getTranslation(text, Option["sl"], Option["tl"][i], Option["hl"], Option["verbose"], Option["play"] || Option["download-audio"], playlist, il))
             else
                 il[0] = Option["sl"] == "auto" ? "en" : Option["sl"]
 
             if (Option["play"] == 1) {
-                if (Option["player"]) {
+                if (Option["player"])
                     for (j in playlist)
                         play(playlist[j]["text"], playlist[j]["tl"])
-                    if (Option["download-audio"])
-                        download_audio(playlist[length(playlist) - 1]["text"], playlist[length(playlist) - 1]["tl"])
-                } else if (SpeechSynthesizer)
+                else if (SpeechSynthesizer)
                     for (j in playlist)
                         print playlist[j]["text"] | SpeechSynthesizer
             } else if (Option["play"] == 2) {
-                if (Option["player"]) {
+                if (Option["player"])
                     play(text, il[0])
-                    if (Option["download-audio"])
-                        download_audio(text, il[0])
-                } else if (SpeechSynthesizer)
+                else if (SpeechSynthesizer)
                     print text | SpeechSynthesizer
+            }
+
+            if (Option["download-audio"] == 1) {
+                # Download the translation unless used with -sp or -no-trans
+                if (Option["play"] != 2 && !Option["no-translate"])
+                    download_audio(playlist[length(playlist) - 1]["text"], \
+                                   playlist[length(playlist) - 1]["tl"])
+                else
+                    download_audio(text, il[0])
             }
         }
     }

--- a/include/Translators/Apertium.awk
+++ b/include/Translators/Apertium.awk
@@ -51,6 +51,8 @@ function apertiumTranslate(text, sl, tl, hl,
     _sl = "auto" == _sl ? "en" : _sl
 
     content = getResponse(text, _sl, _tl, _hl)
+    if (Option["dump"])
+        return content
     tokenize(tokens, content)
     parseJson(ast, tokens)
 

--- a/include/Translators/BingTranslator.awk
+++ b/include/Translators/BingTranslator.awk
@@ -183,6 +183,8 @@ function bingTranslate(text, sl, tl, hl,
     bingSetCookie() # must!
 
     content = bingPost(text, _sl, _tl, _hl)
+    if (Option["dump"])
+        return content
     tokenize(tokens, content)
     parseJson(ast, tokens)
 

--- a/include/Translators/GoogleTranslate.awk
+++ b/include/Translators/GoogleTranslate.awk
@@ -110,6 +110,8 @@ function googleTranslate(text, sl, tl, hl,
     _tl = getCode(tl); if (!_tl) _tl = tl
     _hl = getCode(hl); if (!_hl) _hl = hl
     content = getResponse(text, _sl, _tl, _hl)
+    if (Option["dump"])
+        return content
     tokenize(tokens, content)
     parseJsonArray(ast, tokens)
 

--- a/include/Translators/YandexTranslate.awk
+++ b/include/Translators/YandexTranslate.awk
@@ -141,6 +141,8 @@ function yandexTranslate(text, sl, tl, hl,
     _hl = getCode(hl); if (!_hl) _hl = hl
 
     content = getResponse(text, _sl, _tl, _hl)
+    if (Option["dump"])
+        return content
     tokenize(tokens, content)
     parseJson(ast, tokens)
 

--- a/include/Utils.awk
+++ b/include/Utils.awk
@@ -140,20 +140,28 @@ function emacsMe(    i, params, el, command) {
 }
 
 # Fetch the content of a URL. Return a null string if failed.
-function curl(url,    command, content, line) {
+function curl(url, output,    command, content, line) {
     initCurl()
 
     if (!Curl) {
         l(">> not found: curl")
         w("[WARNING] curl is not found.")
         return NULLSTR
-    } else {
-        command = Curl " --location --silent " parameterize(url)
-        content = NULLSTR
-        while ((command |& getline line) > 0)
-            content = (content ? content "\n" : NULLSTR) line
-        return content
     }
+
+    command = Curl " --location --silent"
+    if (Option["user-agent"])
+        command = command " --user-agent " parameterize(Option["user-agent"])
+    command = command " " parameterize(url)
+    if (output) {
+        command = command " --output " parameterize(output)
+        system(command)
+        return NULLSTR
+    }
+    content = NULLSTR
+    while ((command |& getline line) > 0)
+        content = (content ? content "\n" : NULLSTR) line
+    return content
 }
 
 # Dump a Unicode string into a byte array. Return the length of the array.

--- a/man/trans.1
+++ b/man/trans.1
@@ -207,6 +207,11 @@ Do not autocorrect.
 Do not convert bidirectional texts.
 .RS
 .RE
+.TP
+.B \f[B]\-dump\f[]
+Print raw API response instead.
+.RS
+.RE
 .SS Audio options
 .TP
 .B \f[B]\-p\f[], \f[B]\-play\f[]

--- a/man/trans.1
+++ b/man/trans.1
@@ -260,6 +260,16 @@ Do not listen to the translation.
 Do not translate anything when using \-speak.
 .RS
 .RE
+.TP
+.B \f[B]\-download\-audio\f[]
+Download the audio to the current directory.
+.RS
+.RE
+.TP
+.B \f[B]\-download\-audio\-as\f[] \f[I]FILENAME\f[]
+Download the audio to the specified file.
+.RS
+.RE
 .SS Terminal paging and browsing options
 .TP
 .B \f[B]\-v\f[], \f[B]\-view\f[]

--- a/man/trans.1.md
+++ b/man/trans.1.md
@@ -127,6 +127,9 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 **-no-bidi**
 :   Do not convert bidirectional texts.
 
+**-dump**
+:   Print raw API response instead.
+
 ## Audio options
 
 **-p**, **-play**

--- a/man/trans.1.md
+++ b/man/trans.1.md
@@ -158,6 +158,12 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 **-no-translate**
 :   Do not translate anything when using -speak.
 
+**-download-audio**
+:   Download the audio to the current directory.
+
+**-download-audio-as** *FILENAME*
+:   Download the audio to the specified file.
+
 ## Terminal paging and browsing options
 
 **-v**, **-view**

--- a/man/trans.1.template.md
+++ b/man/trans.1.template.md
@@ -127,6 +127,9 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 **-no-bidi**
 :   Do not convert bidirectional texts.
 
+**-dump**
+:   Print raw API response instead.
+
 ## Audio options
 
 **-p**, **-play**

--- a/man/trans.1.template.md
+++ b/man/trans.1.template.md
@@ -158,6 +158,12 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 **-no-translate**
 :   Do not translate anything when using -speak.
 
+**-download-audio**
+:   Download the audio to the current directory.
+
+**-download-audio-as** *FILENAME*
+:   Download the audio to the specified file.
+
 ## Terminal paging and browsing options
 
 **-v**, **-view**


### PR DESCRIPTION
The option `-dump` dumps the raw API response (almost always JSON) to the stdout for future consumption (by a 3rd party program):

```
$ trans -dump :fi 'hello world'
[[["Hei maailma","hello world",null,null,1]],null,"en",null,null,[["hello world",null,[["Hei maailma",1000,true,false],["hello maailma",0,true,false],["Hello World",0,true,false]],[[0,11]],"hello world",0,0]],1,null,[["en"],null,[1],["en"]],null,null,null,null,null,[["World"]]]
```

The option `-download-audio` downloads the Text-to-Speech audio into the current folder (#77). It by default uses the translated text; when used in combination with `-speak` or `-no-trans` it yields the audio of the original text. (Known issue: `-no-trans` doesn't work with Bing engine.)

```
$ trans -download-audio :fi 'hello world'
```

Alternatively, `-download-audio-as` may be used to specify a filename:

```
$ trans -download-audio-as=output.ts :fi 'hello world'
```
