### PR TITLE
Get output patch

### DIFF
--- a/include/Commons.awk
+++ b/include/Commons.awk
@@ -557,6 +557,7 @@ function getOutput(command,    content, line) {
     content = NULLSTR
     while ((command |& getline line) > 0)
         content = (content ? content "\n" : NULLSTR) line
+    close(command)
     return content
 }
 

--- a/include/Utils.awk
+++ b/include/Utils.awk
@@ -164,6 +164,7 @@ function curl(url, output,    command, content, line) {
     content = NULLSTR
     while ((command |& getline line) > 0)
         content = (content ? content "\n" : NULLSTR) line
+    close(command)
     return content
 }
 
@@ -192,6 +193,7 @@ function curlPost(url, data, output,    command, content, line) {
     content = NULLSTR
     while ((command |& getline line) > 0)
         content = (content ? content "\n" : NULLSTR) line
+    close(command)    
     return content
 }
 


### PR DESCRIPTION
You should close the command in `getOutput`, `curl` and `curlPost`. If you call the same command twice, the second call will have no output. Some examples:

    print getOutput("pwd")
    print getOutput("pwd")
    
    print curl("http://example.com/")
    print curl("http://example.com/")

It seems that these functions are rarely called with the same command, that's why no bug has occurred so far.

P.S. I learned a lot of awk thanks to your project!
