### PR TITLE
Use typeof (required gawk >= 4.2.0) in isnum function

### DIFF
--- a/include/Commons.awk
+++ b/include/Commons.awk
@@ -93,7 +93,7 @@ function compareByIndexFields(i1, v1, i2, v2,
 # Return non-zero if the string represents a numeral;
 # Otherwise, return 0.
 function isnum(string) {
-    return string == string + 0
+    return typeof(string) == "number"
 }
 
 # Return one of the substrings if the string starts with it;


### PR DESCRIPTION
I use gawk 4.2.1 and noticed that the `parseJson` function is a little buggy. Consider the following snippet

```gawk
    SUBSEP = "@"
    d = "{type: command}"
    tokenize (tokens, d)
    parseJson (ast, tokens)
    printArr (ast)
```

give me (`printArr` print the entire array in `key : value` format) :  

```
0@ : command
```

It didn't parse the `type` string. This is because, `isnum` eval all `unassigned` type variable to `1`, which is the case (`stack[p]` is unassigned) in the following line.

https://github.com/soimort/translate-shell/blob/2399bb73eda83ca825a10cd6781809ea491052ae/include/Parser.awk#L283

A solution is to use the function `typeof` to determine correctly the type of a variable (but this function first appeared in gawk 4.2.0) : 

```gawk
function isnum(string) {
    return typeof(string) == "number"
}
```
In this way, the example above give me : 

```
0@type : command
```

which is correct.
