### PR TITLE
Support emoji on Yandex.Translate

### DIFF
--- a/include/Languages.awk
+++ b/include/Languages.awk
@@ -1816,6 +1816,11 @@ function initLocale(    i) {
     Locale["chr"]["glotto"]            = "cher1273"
     Locale["chr"]["script"]            = "Cher"
 
+    #? Emoji
+    Locale["emj"]["support"]           = "yandex-only"
+    Locale["emj"]["name"]              = "Emoji"
+    Locale["emj"]["endonym"]           = "Emoji"
+
     for (i in Locale) {
         # Initialize strings for displaying endonyms of locales
         Locale[i]["display"] = show(Locale[i]["endonym"], i)

--- a/include/Translators/YandexTranslate.awk
+++ b/include/Translators/YandexTranslate.awk
@@ -155,7 +155,7 @@ function yandexTranslate(text, sl, tl, hl,
 
     # Transliteration
     wShowTranslationPhonetics = Option["show-translation-phonetics"]
-    if (wShowTranslationPhonetics) {
+    if (wShowTranslationPhonetics && _tl != "emj") {
         split(_tl, group, "-")
         data = yandexPostRequestBody(translation, group[1], group[1], _hl, "translit")
         content = curlPost("https://translate.yandex.net/translit/translit", data)
@@ -187,7 +187,7 @@ function yandexTranslate(text, sl, tl, hl,
 
         # Transliteration (original)
         wShowOriginalPhonetics = Option["show-original-phonetics"]
-        if (wShowTranslationPhonetics) {
+        if (wShowTranslationPhonetics && il != "emj") {
             split(il, group, "-")
             data = yandexPostRequestBody(text, group[1], group[1], _hl, "translit")
             content = curlPost("https://translate.yandex.net/translit/translit", data)


### PR DESCRIPTION
By simply specifying the code `emj` as the target language. 
 
This feature is currently yandex-only.

```
$ trans -b -e yandex -t emj 'Eat Pray Love'
🍴 🙏 💏

$ trans -b -e yandex -t emj 'das Denken'
🤔

```