### PR TITLE
Reducing gender bias in Google Translate

### DIFF
--- a/include/Translators/GoogleTranslate.awk
+++ b/include/Translators/GoogleTranslate.awk
@@ -57,7 +57,7 @@ function googleRequestUrl(text, sl, tl, hl,    qc) {
     qc = Option["no-autocorrect"] ? "qc" : "qca";
     return HttpPathPrefix "/translate_a/single?client=gtx"              \
         "&ie=UTF-8&oe=UTF-8"                                            \
-        "&dt=bd&dt=ex&dt=ld&dt=md&dt=rw&dt=rm&dt=ss&dt=t&dt=at"         \
+        "&dt=bd&dt=ex&dt=ld&dt=md&dt=rw&dt=rm&dt=ss&dt=t&dt=at&dt=gt"   \
         "&dt=" qc "&sl=" sl "&tl=" tl "&hl=" hl                         \
         "&q=" preprocess(text)
 }
@@ -196,6 +196,10 @@ function googleTranslate(text, sl, tl, hl,
         # 14 - (original) see also
         if (match(i, "^0" SUBSEP "14" SUBSEP "0" SUBSEP "([[:digit:]]+)$", group))
             oSeeAlso[group[1]] = literal(ast[i])
+
+        # 18 - gender-specific translations
+        if (match(i, "^0" SUBSEP "18" SUBSEP "0" SUBSEP "([[:digit:]]+)" SUBSEP "1$", group))
+            genderedTrans[group[1]] = literal(ast[i])
     }
     PROCINFO["sorted_in"] = saveSortedIn
 
@@ -261,7 +265,14 @@ function googleTranslate(text, sl, tl, hl,
             # Display: major translation & phonetics
             if (r) r = r RS RS
             r = r m("-- display major translation & phonetics")
-            r = r prettify("translation", s(translation, tl))
+            if (!exists(genderedTrans))
+                r = r prettify("translation", s(translation, tl))
+            else {
+                r = r prettify("prompt-message", s("(♂) ", hl))
+                r = r prettify("translation", s(genderedTrans[0], tl)) RS
+                r = r prettify("prompt-message", s("(♀) ", hl))
+                r = r prettify("translation", s(genderedTrans[1], tl))
+            }
             if (wShowTranslationPhonetics)
                 r = r RS prettify("translation-phonetics", showPhonetics(join(phonetics, " "), tl))
         }


### PR DESCRIPTION
Google Translate has been promoting gender-neutrality [1] with respect to many European languages where grammatical genders occur (e.g., French, Italian, Spanish, Turkish) since last year. It makes perfect sense that we do the same as well.

Say, whenever a word / sentence from a gender-insensitive language is translated into a gender-sensitive language, both forms (masculine and feminine) should be displayed, instead of just the masculine form.

[1] https://www.blog.google/products/translate/reducing-gender-bias-google-translate/


![screenshot from 2019-01-03 01-49-45](https://user-images.githubusercontent.com/342945/50620000-22827300-0efd-11e9-940d-eddde8dbfac9.png)
