### PR TITLE
Show HTTP error codes when they happen

### DIFF
--- a/include/Commons.awk
+++ b/include/Commons.awk
@@ -117,6 +117,16 @@ function matchesAny(string, patterns,
     return NULLSTR
 }
 
+# Make the first character of string upper-case.
+function ucfirst(string) {
+    if (length(string) >= 2)
+        return toupper(substr(string, 1, 1)) substr(string, 2)
+    else if (length(string) == 1)
+        return toupper(string)
+
+    return NULLSTR
+}
+
 # Replicate a string.
 function replicate(string, len,
                    ####

--- a/include/Translate.awk
+++ b/include/Translate.awk
@@ -148,8 +148,15 @@ function getResponse(text, sl, tl, hl,
             break
     }
 
-    if ((status == "301" || status == "302") && location)
+    if ((status == "301" || status == "302") && location) {
         content = curl(location)
+    } else if (status == "429") {
+        e("[ERROR] " ucfirst(Option["engine"]) " did not return results because rate limiting is in effect")
+        assert(false, "[ERROR] Rate limiting")
+    } else if (status >= "400") {
+        e("[ERROR] " ucfirst(Option["engine"]) " returned an error response. HTTP status code: " status)
+        assert(false, "[ERROR] Other HTTP error")
+    }
 
     return assert(content, "[ERROR] Null response.")
 }
@@ -218,6 +225,12 @@ function postResponse(text, sl, tl, hl, type,
     if ((status == "301" || status == "302") && location) {
         url = "https" substr(url, 5) # switch to HTTPS; don't use location!
         content = curlPost(url, reqBody)
+    } else if (status == "429") {
+        e("[ERROR] " ucfirst(Option["engine"]) " did not return results because rate limiting is in effect")
+        assert(false, "[ERROR] Rate limiting")
+    } else if (status >= "400") {
+        e("[ERROR] " ucfirst(Option["engine"]) " returned an error response. HTTP status code: " status)
+        assert(false, "[ERROR] Other HTTP error")
     }
 
     return content


### PR DESCRIPTION
This way it's possible to inform the user about rate limiting or other issues.

By using `assert` it remains feasible to `-dump` the response.

Refs #370, #359