### PR TITLE
Add swap command to REPL

### DIFF
--- a/include/REPL.awk
+++ b/include/REPL.awk
@@ -147,6 +147,10 @@ function repl(line,    command, group, name, i, value, words) {
     } else if (command ~ /^:show$/) {
         name = words[2]
         print prettify("welcome-submessage", toString(Option[name], 1, 0, 1))
+    } else if (command ~ /^:swap$/) {
+        tl = Option["tl"][1]
+        Option["tl"][1] = Option["sls"][1]
+        Option["sls"][1] = tl
     } else if (command ~ /^:engine$/) {
         value = words[2]
         Option["engine"] = value


### PR DESCRIPTION
### Description
This PR adds `:swap` command to interactive mode. Command swaps source language and target language.  
Example:
```bash
└> $ trans en:fr -I
Translate Shell
(:q to quit)
English> :swap
Français> :swap
English> 
```
### Motivation
In the case of working with a pair of languages, there may often be a need to swap source and target languages. As far as I understand, these is no other way to work in shell mode with both, for example, `en:fr` and `fr:en`  at the same time, but to open two tabs in terminal each for `en:fr` and `fr:en`. I suppose that `:swap` command can be useful for the described case.
