### PR TITLE
Try to reach Apertium-apy in http://localhost:2737/ rather than the (…

### DIFF
--- a/include/Translators/Apertium.awk
+++ b/include/Translators/Apertium.awk
@@ -7,12 +7,12 @@ BEGIN { provides("apertium") }
 
 function apertiumInit() {
     HttpProtocol = "http://"
-    HttpHost = "www.apertium.org"
-    HttpPort = 80
+    HttpHost = "localhost"
+    HttpPort = 2737
 }
 
 function apertiumRequestUrl(text, sl, tl, hl) {
-    return HttpPathPrefix "/apy/translate?"                             \
+    return HttpPathPrefix "/translate?"                                 \
         "langpair=" preprocess(sl) "|" preprocess(tl)                   \
         "&q=" preprocess(text)
 }


### PR DESCRIPTION
This makes Apertium module target an install of Apertium in the same computer where translate-shell is running (by default it listens in http://localhost:2737).

A working setup can be easily obtained by installing a pre-packaged version of Apertium (e.g. [Debian](https://wiki.apertium.org/wiki/Apertium-apy/Debian) or [Fedora](https://wiki.apertium.org/wiki/Apertium-apy/Fedora)). No further configuration is necessary.

This fixes issue #378.
