### PR TITLE
Add compact option for compact dictionary output

### DIFF
--- a/include/Main.awk
+++ b/include/Main.awk
@@ -24,6 +24,7 @@ function init() {
 
     # Display
     Option["verbose"] = 1
+    Option["compact"] = 0
     Option["show-original"] = 1
     Option["show-original-phonetics"] = 1
     Option["show-translation"] = 1
@@ -341,6 +342,13 @@ BEGIN {
         match(ARGV[pos], /^--?verbose$/)
         if (RSTART) {
             Option["verbose"] = 1 # default value
+            continue
+        }
+
+        # -compact
+        match(ARGV[pos], /^--?(c|compact)$/)
+        if (RSTART) {
+            Option["compact"] = 1
             continue
         }
 

--- a/include/Translators/GoogleTranslate.awk
+++ b/include/Translators/GoogleTranslate.awk
@@ -89,7 +89,7 @@ function googleTranslate(text, sl, tl, hl,
                          wShowTranslation, wShowTranslationPhonetics,
                          wShowPromptMessage, wShowLanguages,
                          wShowOriginalDictionary, wShowDictionary,
-                         wShowAlternatives,
+                         wShowDictionaryCompact, wShowAlternatives,
                          genderedTrans, hasWordClasses, hasAltTranslations,
                          i, j, k, group, temp, saveSortedIn) {
     isPhonetic = match(tl, /^@/)
@@ -235,6 +235,7 @@ function googleTranslate(text, sl, tl, hl,
         wShowLanguages = Option["show-languages"]
         wShowOriginalDictionary = Option["show-original-dictionary"]
         wShowDictionary = Option["show-dictionary"]
+        wShowDictionaryCompact = Option["compact"]
         wShowAlternatives = Option["show-alternatives"]
 
         if (!anything(oPhonetics)) wShowOriginalPhonetics = 0
@@ -429,10 +430,17 @@ function googleTranslate(text, sl, tl, hl,
                     }
 
                     r = r RS prettify("dictionary-word", ins(1, (article ? "(" article ") " : "") word, tl))
-                    if (isRTL(il))
-                        r = r RS prettify("dictionary-explanation-item", ins(2, explanation, il))
-                    else
-                        r = r RS ins(2, explanation)
+                    if (wShowDictionaryCompact) {
+                        if (isRTL(il))
+                            r = r " - " prettify("dictionary-explanation-item", ins(0, explanation, il))
+                        else
+                            r = r " - " ins(0, explanation)
+                    } else {
+                        if (isRTL(il))
+                            r = r RS prettify("dictionary-explanation-item", ins(2, explanation, il))
+                        else
+                            r = r RS ins(2, explanation)
+                    }
                 }
             }
         }

--- a/man/trans.1
+++ b/man/trans.1
@@ -85,6 +85,13 @@ This option is unnecessary in most cases since verbose mode is enabled
 by default.
 .RE
 .TP
+.B \f[B]\-c\f[R], \f[B]\-compact\f[R]
+Compact mode.
+.RS
+.PP
+Show one translate dictionary entry per line instead of splitting it into two lines.
+.RE
+.TP
 .B \f[B]\-b\f[R], \f[B]\-brief\f[R]
 Brief mode.
 .RS

--- a/man/trans.1.md
+++ b/man/trans.1.md
@@ -72,6 +72,11 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 
     This option is unnecessary in most cases since verbose mode is enabled by default.
 
+**-c**, **-compact**
+:   Compact mode.
+
+    Show one translate dictionary entry per line instead of splitting it into two lines.
+
 **-b**, **-brief**
 :   Brief mode.
 

--- a/man/trans.1.template.md
+++ b/man/trans.1.template.md
@@ -72,6 +72,11 @@ If neither *TEXT* nor the input file is specified by command-line arguments, the
 
     This option is unnecessary in most cases since verbose mode is enabled by default.
 
+**-c**, **-compact**
+:   Compact mode.
+
+    Show one translate dictionary entry per line instead of splitting it into two lines.
+
 **-b**, **-brief**
 :   Brief mode.
 


### PR DESCRIPTION
Hi, first of all I would like to thank you for such wonderful project! It makes my translations really quick and allows me to return to reading straightaway without being distracted by overloaded translation services in the web browser.

In this issue I would like to resolve a little problem I ran into. For convenient reading of hieroglyphs, I increased the font size in my terminal and now it fits a slightly smaller number of lines than before and pretty often translate-shell output doesn't fit in one page, so I have to scroll terminal buffer within my tmux session which is quite tedious.

Let's take a look at output of `trans -s zh-CN -t en 量`:

```
量
(Liàng)

quantity

Definitions of 量
[ 简体中文 -> English ]

noun
    amount
        量, 额, 数量, 多少, 数目, 数字
    volume
        卷, 体积, 音量, 量, 额, 册
    quantity
        数量, 量, 份量, 额
    capacity
        容量, 量, 才能, 潜力, 器
    measure
        措施, 测度, 度量, 量, 度, 手段
    quantum
        量子, 量, 额, 限量
    estimate
        预算, 量, 揆
    mete
        量

verb
    amount
        量, 等于, 合计, 共计, 折合, 为数
    measure
        测量, 衡量, 测, 计量, 量, 衡
    estimate
        估计, 预计, 估, 估量, 量, 计量
    mete
        量

adjective
    quantitative
        量

量
    quantity, the amount, amount
```

As you can see this content takes a lot of terminal lines. It could be a significantly more compact if dictionary would place translation on one line with the definitions, e. g.:

```
    amount - 量, 额, 数量, 多少, 数目, 数字
```

instead of 

```
    amount
        量, 额, 数量, 多少, 数目, 数字
```

So I decided to dig into the codebase of translate-shell and found a solution:

```
--- a/include/Translators/GoogleTranslate.awk
+++ b/include/Translators/GoogleTranslate.awk
@@ -430,9 +430,9 @@ function googleTranslate(text, sl, tl, hl,
 
                     r = r RS prettify("dictionary-word", ins(1, (article ? "(" article ") " : "") word, tl))
                     if (isRTL(il))
-                        r = r RS prettify("dictionary-explanation-item", ins(2, explanation, il))
+                        r = r " - " prettify("dictionary-explanation-item", ins(0, explanation, il))
                     else
-                        r = r RS ins(2, explanation)
+                        r = r " - " ins(0, explanation)
                 }
             }
         }
```


I tried to put this functionality into a command-line option to avoid disturbing users who are accustomed to the current broad output. I'm pretty sure I didn't do it 100% right, so I'll be happy to correct the patch of this MR to match the requirements of the project :)